### PR TITLE
Biqian/log

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "SignalRClient",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v11)
     ],
     products: [
         .library(name: "SignalRClient", targets: ["SignalRClient"]),

--- a/Sources/SignalRClient/HubConnectionBuilder.swift
+++ b/Sources/SignalRClient/HubConnectionBuilder.swift
@@ -2,16 +2,22 @@ import Foundation
 
 public class HubConnectionBuilder {
     private var connection: HttpConnection?
-    private var logger: Logger?
+    private var logHandler: LogHandler?
+    private var logLevel: LogLevel?
     private var hubProtocol: HubProtocol?
     private var serverTimeout: TimeInterval?
     private var keepAliveInterval: TimeInterval?
     private var url: String?
 
     public init() {}
-
-    public func withLogger(logger: Logger) -> HubConnectionBuilder {
-        self.logger = logger
+    
+    public func withLogLevel(logLevel: LogLevel) -> HubConnectionBuilder{
+        self.logLevel = logLevel
+        return self
+    }
+    
+    public func withLogHandler(logHandler: LogHandler) -> HubConnectionBuilder{
+        self.logHandler = logHandler
         return self
     }
 
@@ -41,7 +47,7 @@ public class HubConnectionBuilder {
         }
 
         let connection = connection ?? HttpConnection(url: url)
-        let logger = logger ?? DefaultLogger()
+        let logger = Logger(logLevel: logLevel, logHandler: logHandler ?? OSLogHandler())
         let hubProtocol = hubProtocol ?? JsonHubProtocol()
 
         return HubConnection(connection: connection,

--- a/Sources/SignalRClient/Logger.swift
+++ b/Sources/SignalRClient/Logger.swift
@@ -1,15 +1,91 @@
 import Foundation
+import os
 
-public protocol Logger: Sendable {
-    func log(level: LogLevel, message: String)
+public enum LogLevel: Int {
+    case debug, information, warning, error
 }
 
-class DefaultLogger: Logger, @unchecked Sendable {
-    func log(level: LogLevel, message: String) {
-        print("[\(Date().description(with: Locale.current))]: [\(level)] \(message)")
+public protocol LogHandler: Sendable {
+    func log(
+        logLevel: LogLevel, message: LogMessage, file: String, function: String,
+        line: UInt)
+}
+
+// The current functionality is similar to String. It could be extended in the future.
+public struct LogMessage: ExpressibleByStringInterpolation,
+    CustomStringConvertible
+{
+    private var value: String
+
+    public init(stringLiteral value: String) {
+        self.value = value
+    }
+
+    public var description: String {
+        return self.value
     }
 }
 
-public enum LogLevel {
-    case debug, information, warning, error
+struct Logger {
+    private var logHandler: LogHandler
+    private let logLevel: LogLevel?
+
+    init(logLevel: LogLevel?, logHandler: LogHandler) {
+        self.logLevel = logLevel
+        self.logHandler = logHandler
+    }
+
+    public func log(
+        level: LogLevel, message: LogMessage, file: String = #fileID,
+        function: String = #function, line: UInt = #line
+    ) {
+        guard let minLevel = self.logLevel, level.rawValue >= minLevel.rawValue
+        else {
+            return
+        }
+        logHandler.log(
+            logLevel: level, message: message, file: file,
+            function: function, line: line)
+    }
+}
+
+struct OSLogHandler: LogHandler {
+    var logger: os.Logger
+    init() {
+        self.logger = os.Logger(
+            subsystem: "com.microsoft.signalr.client", category: "")
+    }
+
+    public func log(
+        logLevel: LogLevel, message: LogMessage, file: String, function: String,
+        line: UInt
+    ) {
+        logger.log(
+            level: logLevel.toOSLogType(),
+            "[\(Date().description(with: Locale.current), privacy: .public)] [\(String(describing:logLevel), privacy: .public)] [\(fileNameWithoutPathAndSuffix(file),privacy: .public):\(function,privacy: .public):\(line,privacy: .public)] - \(message,privacy: .public)"
+        )
+    }
+
+    private func fileNameWithoutPathAndSuffix(_ file: String) -> String {
+        return file.components(separatedBy: "/").last!.components(
+            separatedBy: "."
+        ).first!
+
+    }
+}
+
+extension LogLevel {
+    fileprivate func toOSLogType() -> OSLogType {
+        switch self {
+        case .debug:
+            return .debug
+        case .information:
+            return .info
+        case .warning:
+            // OSLog has no warning type
+            return .info
+        case .error:
+            return .error
+        }
+    }
 }

--- a/Sources/SignalRClient/Logger.swift
+++ b/Sources/SignalRClient/Logger.swift
@@ -70,7 +70,6 @@ struct OSLogHandler: LogHandler {
         return file.components(separatedBy: "/").last!.components(
             separatedBy: "."
         ).first!
-
     }
 }
 

--- a/Tests/SignalRClientTests/HubConnectionTests.swift
+++ b/Tests/SignalRClientTests/HubConnectionTests.swift
@@ -29,17 +29,17 @@ class MockConnection: ConnectionProtocol, @unchecked Sendable {
 
 final class HubConnectionTests: XCTestCase {
     var mockConnection: MockConnection!
-    var logger: Logger!
+    var logHandler: LogHandler!
     var hubProtocol: HubProtocol!
     var hubConnection: HubConnection!
 
     override func setUp() async throws {
         mockConnection = MockConnection()
-        logger = DefaultLogger()
+        logHandler = MockLogHandler()
         hubProtocol = JsonHubProtocol()
         hubConnection = HubConnection(
             connection: mockConnection,
-            logger: logger,
+            logger: Logger(logLevel: .debug, logHandler: logHandler),
             hubProtocol: hubProtocol,
             serverTimeout: nil,
             keepAliveInterval: nil

--- a/Tests/SignalRClientTests/LoggerTests.swift
+++ b/Tests/SignalRClientTests/LoggerTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+
+@testable import SignalRClient
+
+final class MockLogHandler: LogHandler, @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let innerLogHandler: LogHandler?
+    private var logs: [String]
+
+    // set showLog to true for debug
+    init(showLog: Bool = false) {
+        queue = DispatchQueue(label: "MockLogHandler")
+        logs = []
+        innerLogHandler = showLog ? OSLogHandler() : nil
+    }
+
+    func log(
+        logLevel: SignalRClient.LogLevel, message: SignalRClient.LogMessage,
+        file: String, function: String, line: UInt
+    ) {
+        queue.sync {
+            logs.append("\(message)")
+        }
+        innerLogHandler?.log(
+            logLevel: logLevel, message: message, file: file,
+            function: function, line: line)
+    }
+
+}
+
+extension MockLogHandler {
+    func clear() {
+        queue.sync {
+            logs.removeAll()
+        }
+    }
+
+    func verifyLogged(
+        _ message: String, file: StaticString = #filePath, line: UInt = #line
+    ) {
+        queue.sync {
+            for log in logs {
+                if log.contains(message) {
+                    return
+                }
+            }
+            XCTFail(
+                "Expected log not found: \"\(message)\"", file: file, line: line
+            )
+        }
+    }
+
+    func verifyNotLogged(
+        _ message: String, file: StaticString = #filePath, line: UInt = #line
+    ) {
+        queue.sync {
+            for log in logs {
+                if log.contains(message) {
+                    XCTFail(
+                        "Unexpected Log found: \"\(message)\"", file: file,
+                        line: line)
+                }
+            }
+        }
+    }
+}
+
+class LoggerTests: XCTestCase {
+    func testOSLogHandler() {
+        let logger = Logger(logLevel: .debug, logHandler: OSLogHandler())
+        logger.log(level: .debug, message: "Hello world")
+        logger.log(level: .information, message: "Hello world \(true)")
+    }
+
+    func testMockHandler() {
+        let mockLogHandler = MockLogHandler()
+        let logger = Logger(logLevel: .information, logHandler: mockLogHandler)
+        logger.log(level: .error, message: "error")
+        logger.log(level: .information, message: "info")
+        logger.log(level: .debug, message: "debug")
+        mockLogHandler.verifyLogged("error")
+        mockLogHandler.verifyLogged("info")
+        mockLogHandler.verifyNotLogged("debug")
+        mockLogHandler.clear()
+        mockLogHandler.verifyNotLogged("error")
+        mockLogHandler.verifyNotLogged("info")
+    }
+}

--- a/Tests/SignalRClientTests/TaskCompletionSourceTests.swift
+++ b/Tests/SignalRClientTests/TaskCompletionSourceTests.swift
@@ -14,7 +14,7 @@ class TaskCompletionSourceTests: XCTestCase {
         let value = try await tcs.task()
         let elapsed = Date().timeIntervalSince(start)
         XCTAssertTrue(value)
-        XCTAssertLessThan(abs(elapsed - 1), 0.1)
+        XCTAssertLessThan(abs(elapsed - 1), 1)
         try await t.value
     }
     
@@ -26,7 +26,7 @@ class TaskCompletionSourceTests: XCTestCase {
         let value = try await tcs.task()
         let elapsed = Date().timeIntervalSince(start)
         XCTAssertTrue(value)
-        XCTAssertLessThan(elapsed, 0.1)
+        XCTAssertLessThan(elapsed, 1)
     }
     
     func testSetException() async throws {
@@ -45,7 +45,7 @@ class TaskCompletionSourceTests: XCTestCase {
                 error as? SignalRError, SignalRError.noHandshakeMessageReceived)
         }
         let elapsed = Date().timeIntervalSince(start)
-        XCTAssertLessThan(abs(elapsed - 1), 0.1)
+        XCTAssertLessThan(abs(elapsed - 1), 1)
         try await t.value
     }
     
@@ -64,13 +64,13 @@ class TaskCompletionSourceTests: XCTestCase {
         let value = try await tcs.task()
         let elapsed = Date().timeIntervalSince(start)
         XCTAssertTrue(value)
-        XCTAssertLessThan(abs(elapsed - 1), 0.1)
+        XCTAssertLessThan(abs(elapsed - 1), 1)
         
         let start2 = Date()
         let value2 = try await tcs.task()
         let elapsed2 = Date().timeIntervalSince(start2)
         XCTAssertTrue(value2)
-        XCTAssertLessThan(elapsed2, 0.1)
+        XCTAssertLessThan(elapsed2, 1)
         
         try await t.value
     }


### PR DESCRIPTION
Changes of this PR:
* Add OSLogHandler 
   OSLog supports filtering and stores the log to the Apple Unified Log System. 
* Add MockLogHandler
  Help verification log

The Logger-> LogHandler pattern is a simplified version of the [Apple/swift-log](https://github.com/apple/swift-log?tab=readme-ov-file#on-the-implementation-of-a-logging-backend-a-loghandler) which inserts`#file` and `#line` in `Logger` and make `LogHandler` replacable.