### PR TITLE
implement underlying sse client

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "10d9b57bca514a2d810d1cdd0b5299cbef5b08e122ecc69933f37d5ab97d745b",
+  "originHash" : "658f837985c79f0539997aa277c572661e5eccf9a6dbf095ee5f7ff7ef0ea133",
   "pins" : [
-    {
-      "identity" : "eventsource",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inaka/EventSource.git",
-      "state" : {
-        "branch" : "78934b3",
-        "revision" : "78934b361891c7d0fa3d399d128e959f0c94d267"
-      }
-    },
     {
       "identity" : "messagepacker",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -10,16 +10,12 @@ let package = Package(
         .library(name: "SignalRClient", targets: ["SignalRClient"])
     ],
     dependencies: [
-        .package(
-            url: "https://github.com/inaka/EventSource.git", revision: "78934b3"
-        ),
         .package(url: "https://github.com/hirotakan/MessagePacker.git", .exact("0.4.7"))
     ],
     targets: [
         .target(
             name: "SignalRClient",
             dependencies: [
-                .product(name: "EventSource", package: "EventSource", condition: .when(platforms: [.macOS, .iOS, .tvOS, .visionOS, .watchOS])),
                 .product(name: "MessagePacker", package: "MessagePacker")
             ]
         ),

--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -441,13 +441,8 @@ actor HttpConnection: ConnectionProtocol {
                     headers: options.headers ?? [:]
                 )
             case .serverSentEvents:
-#if canImport(EventSource)
                 let accessToken = await self.httpClient.accessToken
                 return ServerSentEventTransport(httpClient: self.httpClient, accessToken: accessToken, logger: logger, options: options)
-#else
-                // TODO: Need to better handle this later
-                throw SignalRError.unsupportedTransport
-#endif                
             case .longPolling:
                  return LongPollingTransport(httpClient: httpClient, logger: logger, options: options)
             default:

--- a/Sources/SignalRClient/Transport/EventSource.swift
+++ b/Sources/SignalRClient/Transport/EventSource.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+// A SSE client implementation compatible with SignalR server.
+// Assumptions:
+//   1. No BOM charactor.
+//   2. Connect is only called once
+// Below features are not implemented as SignalR doesn't rely on them:
+//  1. Reconnect, last Id
+//  2. event name, event handlers
+class EventSource: NSObject, URLSessionDataDelegate {
+    private let url: URL
+    private let headers: [String: String]
+    private let parser: EventParser
+    private var openHandler: (() -> Void)?
+    private var completeHandler: ((Int?, Error?) -> Void)?
+    private var messageHandler: ((String) -> Void)?
+    private var urlSession: URLSession?
+
+    init(url: URL, headers: [String: String]?) {
+        self.url = url
+        var headers = headers ?? [:]
+        headers["Accept"] = "text/event-stream"
+        headers["Cache-Control"] = "no-cache"
+        self.headers = headers
+        self.parser = EventParser()
+    }
+
+    func connect() {
+        let config = URLSessionConfiguration.default
+        config.httpAdditionalHeaders = self.headers
+        config.timeoutIntervalForRequest = TimeInterval.infinity
+        config.timeoutIntervalForResource = TimeInterval.infinity
+        self.urlSession = URLSession(
+            configuration: config, delegate: self, delegateQueue: nil)
+        self.urlSession!.dataTask(with: url).resume()
+    }
+
+    func disconnect() {
+        self.urlSession?.invalidateAndCancel()
+    }
+
+    func onOpen(openHandler: @escaping (() -> Void)) {
+        self.openHandler = openHandler
+    }
+
+    func onComplete(
+        completionHandler: @escaping (Int?, Error?) -> Void
+    ) {
+        self.completeHandler = completionHandler
+    }
+
+    func onMessage(messageHandler: @escaping (String) -> Void) {
+        self.messageHandler = messageHandler
+    }
+
+    // MARK: redirect
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        var newRequest = request
+        self.headers.forEach { key, value in
+            newRequest.setValue(value, forHTTPHeaderField: key)
+        }
+        completionHandler(newRequest)
+    }
+
+    // MARK: open
+    public func urlSession(
+        _ session: URLSession, dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition)
+            -> Void
+    ) {
+        let statusCode = (response as? HTTPURLResponse)?.statusCode
+        if statusCode == 200 {
+            self.openHandler?()
+        }
+        // forward anyway
+        completionHandler(URLSession.ResponseDisposition.allow)
+    }
+
+    // MARK: data
+    public func urlSession(
+        _ session: URLSession, dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        parser.Parse(data: data).forEach { event in
+            self.messageHandler?(event)
+        }
+    }
+
+    // MARK: complete
+    public func urlSession(
+        _ session: URLSession, task: URLSessionTask,
+        didCompleteWithError error: (any Error)?
+    ) {
+        let statusCode = (task.response as? HTTPURLResponse)?.statusCode
+        self.completeHandler?(statusCode, error)
+    }
+}
+
+// The parser supports both "\n" and "\r\n" as field separator. "\r" is rarely used practically thus not supported for simplicity.
+// Comments and fields other than "data" are silently dropped.
+class EventParser {
+    static let cr = Character("\r").asciiValue!
+    static let ln = Character("\n").asciiValue!
+    static let dot = Character(":").asciiValue!
+    static let space = Character(" ").asciiValue!
+    static let data = "data".data(using: .utf8)!
+
+    private var lines: [String]
+    private var buffer: Data
+
+    init() {
+        self.lines = []
+        self.buffer = Data()
+    }
+
+    func Parse(data: Data) -> [String] {
+        var events: [String] = []
+        var data = data
+        while let index = data.firstIndex(of: EventParser.ln) {
+            var segment = data[..<index]
+            data = data[(index + 1)...]
+
+            if segment.last == EventParser.cr {
+                segment = segment.dropLast()
+            }
+            buffer.append(segment)
+
+            var line = buffer
+            buffer = Data()
+
+            if line.isEmpty {
+                if lines.count > 0 {
+                    events.append(lines.joined(separator: "\n"))
+                    lines = []
+                }
+            } else {
+                guard line.starts(with: EventParser.data) else {
+                    continue
+                }
+                line = line[EventParser.data.count...]
+                guard !line.isEmpty else {
+                    lines.append("")
+                    continue
+                }
+                guard line.first == EventParser.dot else {
+                    continue
+                }
+                line = line.dropFirst()
+                if line.first == EventParser.space {
+                    line = line.dropFirst()
+                }
+                guard let line = String(data: line, encoding: .utf8) else {
+                    continue
+                }
+                lines.append(line)
+            }
+        }
+        buffer.append(data)
+
+        return events
+    }
+}

--- a/Sources/SignalRClient/Transport/ServerSentEventTransport.swift
+++ b/Sources/SignalRClient/Transport/ServerSentEventTransport.swift
@@ -1,5 +1,3 @@
-#if canImport(EventSource)
-import EventSource
 import Foundation
 
 actor ServerSentEventTransport: Transport {
@@ -206,7 +204,6 @@ extension EventSourceAdaptor {
         try await start(url: url, headers: headers)
     }
 }
-#endif
 
 public protocol EventSourceAdaptor: Sendable {
     func start(url: String, headers: [String: String]) async throws

--- a/Tests/SignalRClientTests/EventSourceTests.swift
+++ b/Tests/SignalRClientTests/EventSourceTests.swift
@@ -1,4 +1,3 @@
-import EventSource
 import Foundation
 import XCTest
 

--- a/Tests/SignalRClientTests/EventSourceTests.swift
+++ b/Tests/SignalRClientTests/EventSourceTests.swift
@@ -1,0 +1,97 @@
+import EventSource
+import Foundation
+import XCTest
+
+@testable import SignalRClient
+
+class EventSourceTests: XCTestCase {
+    func testEventParser() async throws {
+        let parser = EventParser()
+
+        var content = "data:hello\n\n".data(using: .utf8)!
+        var events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "hello")
+
+        content = "data: hello\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "hello")
+
+        content = "data: hello\r\n\r\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "hello")
+
+        content = "data: hello\r\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "hello")
+
+        content = "data:  hello\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], " hello")
+
+        content = "data:\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "")
+
+        content = "data\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "")
+
+        content = "data\ndata\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "\n")
+
+        content = "data:\ndata\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "\n")
+
+        content = "dat".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 0)
+
+        content = "a:e\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "e")
+
+        content = ":\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 0)
+
+        content = "retry:abc\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 0)
+
+        content = "dataa:abc\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 0)
+
+        content = "Data:abc\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 0)
+
+        content = "data:abc \ndata\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "abc \n")
+
+        content = "data:abc \ndata:efg\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0], "abc \nefg")
+
+        content = "data:abc \ndata:efg\n\nretry\ndata:h\n\n".data(using: .utf8)!
+        events = parser.Parse(data: content)
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events[0], "abc \nefg")
+        XCTAssertEqual(events[1], "h")
+    }
+}


### PR DESCRIPTION
Implement [SSE Protocol](https://html.spec.whatwg.org/multipage/server-sent-events.html) :

1. The client is compatible with [SignalR server](https://github.com/dotnet/aspnetcore/blob/6ae3ea387b20f6497b82897d613e9b8a6e31d69c/src/SignalR/common/Http.Connections/src/Internal/Transports/ServerSentEventsServerTransport.cs#L66). 

2. `Reconnect`, `last ID`, `event handlers` are not implemented.