### PR TITLE
Add Messagepack protocol implementation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,13 +10,11 @@ let package = Package(
         .library(name: "SignalRClient", targets: ["SignalRClient"])
     ],
     dependencies: [
-        .package(url: "https://github.com/hirotakan/MessagePacker.git", .exact("0.4.7"))
     ],
     targets: [
         .target(
             name: "SignalRClient",
             dependencies: [
-                .product(name: "MessagePacker", package: "MessagePacker")
             ]
         ),
         .testTarget(

--- a/Sources/SignalRClient/Protocols/BinaryMessageFormat.swift
+++ b/Sources/SignalRClient/Protocols/BinaryMessageFormat.swift
@@ -35,7 +35,7 @@ class BinaryMessageFormat {
             if index + Int(number) > data.count {
                 throw SignalRError.incompleteMessage
             }
-            let message = data[index..<(index + Int(number))]
+            let message = data.subdata(in: index..<(index + Int(number)))
             messages.append(message)
             index += Int(number)
         }

--- a/Sources/SignalRClient/Protocols/MessagePackHubProtocol.swift
+++ b/Sources/SignalRClient/Protocols/MessagePackHubProtocol.swift
@@ -99,9 +99,9 @@ final class MessagePackHubProtocol: HubProtocol {
     func parseMessage(message: Data, binder: any InvocationBinder)
         throws -> HubMessage?
     {
-        let (msgpackType, _ ) = try MsgpackType.parse(data: message)
+        let (msgpackElement, _ ) = try MsgpackElement.parse(data: message)
         let decoder = MsgpackDecoder()
-        try decoder.loadMsgpackType(msgpackType)
+        try decoder.loadMsgpackElement(from: msgpackElement)
         var container = try decoder.unkeyedContainer()
         guard
             let messageType = MessageType(

--- a/Sources/SignalRClient/Protocols/MessagePackHubProtocol.swift
+++ b/Sources/SignalRClient/Protocols/MessagePackHubProtocol.swift
@@ -1,5 +1,4 @@
 import Foundation
-import MessagePacker
 
 final class MessagePackHubProtocol: HubProtocol {
     let name = "messagepack"
@@ -92,7 +91,7 @@ final class MessagePackHubProtocol: HubProtocol {
         default:
             throw SignalRError.unexpectedMessageType("\(type(of: message))")
         }
-        let messageData = try MessagePackEncoder().encode(
+        let messageData = try MsgpackEncoder().encode(
             AnyEncodableArray(arr))
         return try .data(BinaryMessageFormat.write(messageData))
     }
@@ -100,7 +99,9 @@ final class MessagePackHubProtocol: HubProtocol {
     func parseMessage(message: Data, binder: any InvocationBinder)
         throws -> HubMessage?
     {
-        let decoder = MessagePackDecoder(referencing: message)
+        let (msgpackType, _ ) = try MsgpackType.parse(data: message)
+        let decoder = MsgpackDecoder()
+        try decoder.loadMsgpackType(msgpackType)
         var container = try decoder.unkeyedContainer()
         guard
             let messageType = MessageType(

--- a/Sources/SignalRClient/Protocols/msgpack/MsgpackCommon.swift
+++ b/Sources/SignalRClient/Protocols/msgpack/MsgpackCommon.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+// Messagepack protocol: https://github.com/msgpack/msgpack/blob/master/spec.md
+
+// MARK: Public
+// Predefined Timstamp Extension
+public struct MsgpackTimestamp: Equatable {
+    var seconds: Int64
+    var nanoseconds: UInt32
+}
+
+// Those encoding extension methods are rarely used unless you want to encode to messagepack extension type
+extension Encoder {
+    public func isMsgpackEncoder() -> Bool {
+        return self is MsgpackEncoder
+    }
+
+    // This method should be used with MsgpackEncoder otherwise it panics. Use isMsgpackEncoder to check.
+    public func encodeMsgpackExt(extType: Int8, extData: Data) throws {
+        let msgpackEncoder = self as! MsgpackEncoder
+        try msgpackEncoder.encodeMsgpackExt(extType: extType, extData: extData)
+    }
+}
+
+// Those decoding extension methods are rarely used unless you want to decode from messagepack extension type
+extension Decoder {
+    public func isMsgpackDecoder() -> Bool {
+        return self is MsgpackDecoder
+    }
+
+    // This method should be used with MsgpackDecoder otherwise it panics. Use isMsgpackDecoder to check.
+    public func getMsgpackExtType() throws -> Int8 {
+        let msgpackDecoder = self as! MsgpackDecoder
+        return try msgpackDecoder.getMsgpackExtType()
+    }
+
+    // This method should be used with MsgpackDecoder otherwise it panics. Use isMsgpackDecoder to check.
+    public func getMsgpackExtData() throws -> Data {
+        let msgpackDecoder = self as! MsgpackDecoder
+        return try msgpackDecoder.getMsgpackExtData()
+    }
+}
+
+// MARK: Internal
+enum MsgpackType: Equatable {
+    case int(Int64)
+    case uint(UInt64)
+    case float32(Float32)
+    case float64(Float64)
+    case string(String)
+    case bin(Data)
+    case bool(Bool)
+    case map([String: MsgpackType])
+    case array([MsgpackType])
+    case null
+    case ext(Int8, Data)
+
+    var typeDescription: String {
+        switch self {
+        case .bool:
+            return "Bool"
+        case .int, .uint:
+            return "Integer"
+        case .float32, .float64:
+            return "Float"
+        case .string:
+            return "String"
+        case .bin:
+            return "Binary"
+        case .map:
+            return "Map"
+        case .array:
+            return "Array"
+        case .null:
+            return "Null"
+        case .ext(let type, _):
+            return "Extension(type:\(type))"
+        }
+    }
+}
+
+struct MsgpackCodingKey: CodingKey, Equatable {
+    var stringValue: String
+    var intValue: Int?
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = String("Index \(intValue)")
+    }
+}

--- a/Sources/SignalRClient/Protocols/msgpack/MsgpackCommon.swift
+++ b/Sources/SignalRClient/Protocols/msgpack/MsgpackCommon.swift
@@ -3,7 +3,7 @@ import Foundation
 // Messagepack protocol: https://github.com/msgpack/msgpack/blob/master/spec.md
 
 // MARK: Public
-// Predefined Timstamp Extension
+// Predefined Timestamp Extension
 public struct MsgpackTimestamp: Equatable {
     var seconds: Int64
     var nanoseconds: UInt32
@@ -42,7 +42,7 @@ extension Decoder {
 }
 
 // MARK: Internal
-enum MsgpackType: Equatable {
+enum MsgpackElement: Equatable {
     case int(Int64)
     case uint(UInt64)
     case float32(Float32)
@@ -50,8 +50,8 @@ enum MsgpackType: Equatable {
     case string(String)
     case bin(Data)
     case bool(Bool)
-    case map([String: MsgpackType])
-    case array([MsgpackType])
+    case map([String: MsgpackElement])
+    case array([MsgpackElement])
     case null
     case ext(Int8, Data)
 

--- a/Sources/SignalRClient/Protocols/msgpack/MsgpackDecoder.swift
+++ b/Sources/SignalRClient/Protocols/msgpack/MsgpackDecoder.swift
@@ -1,0 +1,976 @@
+import Foundation
+
+// MARK: Swift Decodable implementation. Decoder, KeyedContainer, UnkeyedContainer, SingleValueContainer
+class MsgpackDecoder: Decoder, MsgpackTypeLoader {
+    var codingPath: [any CodingKey]
+    var messagepackType: MsgpackType?
+    var userInfo: [CodingUserInfoKey: Any]
+
+    init(
+        codingPath: [any CodingKey] = [],
+        userInfo: [CodingUserInfoKey: Any] = [:]
+    ) {
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+    }
+
+    func getMsgpackExtType() throws -> Int8 {
+        guard let msgpackType = self.messagepackType else {
+            throw MsgpackDecodingError.decoderNotInitialized
+        }
+        guard case let MsgpackType.ext(extType, _) = msgpackType else {
+            throw DecodingError.typeMismatch(
+                Decoder.self,
+                .init(
+                    codingPath: codingPath,
+                    debugDescription:
+                        "\(msgpackType.typeDescription) is not extension type"))
+        }
+        return extType
+    }
+
+    func getMsgpackExtData() throws -> Data {
+        guard let msgpackType = self.messagepackType else {
+            throw MsgpackDecodingError.decoderNotInitialized
+        }
+        guard case let MsgpackType.ext(_, data) = msgpackType else {
+            throw DecodingError.typeMismatch(
+                Decoder.self,
+                .init(
+                    codingPath: codingPath,
+                    debugDescription:
+                        "\(msgpackType.typeDescription) is not extension type"))
+        }
+        return data
+    }
+
+    func loadMsgpackType(_ data: MsgpackType) throws {
+        messagepackType = data
+    }
+
+    func container<Key>(keyedBy type: Key.Type) throws
+        -> KeyedDecodingContainer<Key> where Key: CodingKey
+    {
+        guard let messagepackType = messagepackType else {
+            throw MsgpackDecodingError.decoderNotInitialized
+        }
+        let container = try MsgpackKeyedDecodingContainer<Key>(
+            codingPath: codingPath, userInfo: userInfo,
+            msgpackValue: messagepackType)
+        return KeyedDecodingContainer(container)
+    }
+
+    func unkeyedContainer() throws -> any UnkeyedDecodingContainer {
+        guard let messagepackType = messagepackType else {
+            throw MsgpackDecodingError.decoderNotInitialized
+        }
+        let container = try MsgpackUnkeyedDecodingContainer(
+            codingPath: codingPath, userInfo: userInfo,
+            msgpackValue: messagepackType)
+        return container
+    }
+
+    func singleValueContainer() throws -> any SingleValueDecodingContainer {
+        guard let messagepackType = messagepackType else {
+            throw MsgpackDecodingError.decoderNotInitialized
+        }
+        let container = try MsgpackSingleValueDecodingContainer(
+            codingPath: codingPath, userInfo: userInfo,
+            msgpackValue: messagepackType)
+        return container
+    }
+
+    func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        let (msgpackType, remaining) = try MsgpackType.parse(data: data)
+        if !remaining.isEmpty {
+            throw MsgpackDecodingError.corruptMessage
+        }
+        try loadMsgpackType(msgpackType)
+        let result = try msgpackType.decode(type: type, codingPath: codingPath)
+        guard let result = result else {
+            return try type.init(from: self)
+        }
+        return result
+    }
+}
+
+class MsgpackKeyedDecodingContainer<Key: CodingKey>:
+    KeyedDecodingContainerProtocol, MsgpackTypeLoader
+{
+    private var holder: [String: MsgpackType] = [:]
+    var codingPath: [any CodingKey]
+    var userInfo: [CodingUserInfoKey: Any]
+
+    init(
+        codingPath: [any CodingKey], userInfo: [CodingUserInfoKey: Any],
+        msgpackValue: MsgpackType
+    ) throws {
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+        try loadMsgpackType(msgpackValue)
+    }
+
+    func loadMsgpackType(_ data: MsgpackType) throws {
+        switch data {
+        case .map(let m):
+            self.holder = m
+        default:
+            throw DecodingError.typeMismatch(
+                [String: Any].self,
+                .init(
+                    codingPath: codingPath,
+                    debugDescription:
+                        "Expected to decode \([String:Any].self) but found \(data.typeDescription) instead."
+                ))
+
+        }
+    }
+
+    var allKeys: [Key] { holder.keys.compactMap { k in Key(stringValue: k) } }
+
+    func contains(_ key: Key) -> Bool {
+        return holder[key.stringValue] != nil
+    }
+
+    func decodeNil(forKey key: Key) throws -> Bool {
+        let v = try getMsgpackType(key)
+        return v.isNil()
+    }
+
+    func decode<T>(_ value: T.Type, forKey key: Key) throws -> T
+    where T: Decodable {
+        let v = try getMsgpackType(key)
+        let result = try v.decode(
+            type: value, codingPath: subCodingPath(key: key))
+        guard let result = result else {
+            let decoder = try initDecoder(key: key, value: v)
+            return try T.init(from: decoder)
+        }
+        return result
+    }
+
+    func nestedContainer<NestedKey>(
+        keyedBy keyType: NestedKey.Type, forKey key: Key
+    ) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+        let v = try getMsgpackType(key)
+        let decoder = try initDecoder(key: key, value: v)
+        let container = try decoder.container(keyedBy: keyType)
+        return container
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) throws
+        -> any UnkeyedDecodingContainer
+    {
+        let v = try getMsgpackType(key)
+        let decoder = try initDecoder(key: key, value: v)
+        let container = try decoder.unkeyedContainer()
+        return container
+    }
+
+    func superDecoder() throws -> any Decoder {
+        let key = MsgpackCodingKey(stringValue: "super")
+        let v = try getMsgpackType(key)
+        let decoder = try initDecoder(key: key, value: v)
+        return decoder
+    }
+
+    func superDecoder(forKey key: Key) throws -> any Decoder {
+        let v = try getMsgpackType(key)
+        let decoder = try initDecoder(key: key, value: v)
+        return decoder
+    }
+
+    private func getMsgpackType(_ key: CodingKey) throws -> MsgpackType {
+        let v = holder[key.stringValue]
+        guard let v = v else {
+            throw DecodingError.keyNotFound(
+                key,
+                .init(
+                    codingPath: subCodingPath(key: key),
+                    debugDescription: "No value associated with key \(key)."))
+        }
+        return v
+    }
+
+    private func initDecoder(key: CodingKey, value: MsgpackType) throws
+        -> MsgpackDecoder
+    {
+        let decoder = MsgpackDecoder(
+            codingPath: subCodingPath(key: key), userInfo: self.userInfo)
+        try decoder.loadMsgpackType(value)
+        return decoder
+    }
+
+    private func subCodingPath(key: CodingKey) -> [CodingKey] {
+        var codingPath = self.codingPath
+        codingPath.append(key)
+        return codingPath
+    }
+
+}
+
+class MsgpackUnkeyedDecodingContainer: UnkeyedDecodingContainer {
+    private var holder: [MsgpackType] = []
+    var codingPath: [any CodingKey]
+    var userInfo: [CodingUserInfoKey: Any]
+
+    var count: Int? { holder.count }
+    var isAtEnd: Bool { currentIndex >= holder.count }
+    var currentIndex: Int
+
+    init(
+        codingPath: [any CodingKey], userInfo: [CodingUserInfoKey: Any],
+        msgpackValue: MsgpackType
+    ) throws {
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+        self.currentIndex = 0
+        try loadMsgpackType(msgpackValue)
+    }
+
+    func loadMsgpackType(_ data: MsgpackType) throws {
+        switch data {
+        case .array(let m):
+            self.holder = m
+        default:
+            throw DecodingError.typeMismatch(
+                [Any].self,
+                .init(
+                    codingPath: codingPath,
+                    debugDescription:
+                        "Expected to decode \([Any].self) but found \(data.typeDescription) instead."
+                ))
+        }
+    }
+
+    func decodeNil() throws -> Bool {
+        let msgpackType = try getMsgpackType(Never.self)
+        let isNil = msgpackType.isNil()
+        currentIndex += isNil ? 1 : 0
+        return isNil
+    }
+
+    func decode<T>(_ value: T.Type) throws -> T where T: Decodable {
+        let msgpackType = try getMsgpackType(T.self)
+        guard
+            let result = try msgpackType.decode(
+                type: value, codingPath: subCodingPath())
+        else {
+            let decoder = try initDecoder(value: msgpackType)
+            currentIndex += 1
+            return try value.init(from: decoder)
+        }
+        currentIndex += 1
+        return result
+    }
+
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) throws
+        -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey
+    {
+        let msgpackType = try getMsgpackType(
+            KeyedDecodingContainer<NestedKey>.self)
+        let decoder = try initDecoder(value: msgpackType)
+        currentIndex += 1
+        return try decoder.container(keyedBy: keyType)
+    }
+
+    func nestedUnkeyedContainer() throws -> any UnkeyedDecodingContainer {
+        let msgpackType = try getMsgpackType(UnkeyedDecodingContainer.self)
+        let decoder = try initDecoder(value: msgpackType)
+        currentIndex += 1
+        return try decoder.unkeyedContainer()
+    }
+
+    func superDecoder() throws -> any Decoder {
+        let msgpackType = try getMsgpackType(Decoder.self)
+        let decoder = try initDecoder(value: msgpackType)
+        currentIndex += 1
+        return decoder
+    }
+
+    private func getMsgpackType(_ targetType: Any.Type) throws -> MsgpackType {
+        guard currentIndex < holder.count else {
+            throw DecodingError.valueNotFound(
+                targetType,
+                .init(
+                    codingPath: subCodingPath(),
+                    debugDescription: "Unkeyed container is at end."))
+        }
+        return holder[currentIndex]
+    }
+
+    private func initDecoder(value: MsgpackType) throws -> MsgpackDecoder {
+        let decoder = MsgpackDecoder(
+            codingPath: subCodingPath(), userInfo: self.userInfo)
+        try decoder.loadMsgpackType(value)
+        return decoder
+    }
+
+    private func subCodingPath() -> [CodingKey] {
+        var codingPath = self.codingPath
+        codingPath.append(MsgpackCodingKey(intValue: currentIndex))
+        return codingPath
+    }
+}
+
+class MsgpackSingleValueDecodingContainer: SingleValueDecodingContainer,
+    MsgpackTypeLoader
+{
+    private var holder: MsgpackType = .null
+    var codingPath: [any CodingKey]
+    var userInfo: [CodingUserInfoKey: Any]
+
+    init(
+        codingPath: [any CodingKey], userInfo: [CodingUserInfoKey: Any],
+        msgpackValue: MsgpackType
+    ) throws {
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+        try loadMsgpackType(msgpackValue)
+    }
+
+    func loadMsgpackType(_ data: MsgpackType) throws {
+        self.holder = data
+    }
+
+    func decodeNil() -> Bool {
+        return holder.isNil()
+    }
+
+    func decode<T>(_ value: T.Type) throws -> T where T: Decodable {
+        guard
+            let result = try holder.decode(type: value, codingPath: codingPath)
+        else {
+            let decoder = try initDecoder(value: holder)
+            return try value.init(from: decoder)
+        }
+        return result
+    }
+
+    private func initDecoder(value: MsgpackType) throws -> MsgpackDecoder {
+        let decoder = MsgpackDecoder(
+            codingPath: codingPath, userInfo: self.userInfo)
+        try decoder.loadMsgpackType(value)
+        return decoder
+    }
+}
+
+private protocol MsgpackTypeLoader {
+    func loadMsgpackType(_ data: MsgpackType) throws
+}
+
+private enum MsgpackDecodingValue {
+    case MsgpackType(MsgpackType)
+    case Decoded
+}
+
+// MARK: (Decoding Part) Intermediate type which implements messagepack protocol. Similar to JSonObject
+extension MsgpackType {
+    // MARK: Convert from Data to MsgpackType
+    static func parse(data: Data) throws -> (MsgpackType, Data) {
+        try assertLength(data: data, length: 1)
+        let first = data[0]
+        if first <= 0x7f || first >= 0xe0 || (first >= 0xcc && first <= 0xd3) {
+            return try parseNumber(data: data)
+        }
+        if (first >= 0xa0 && first <= 0xbf) || (first >= 0xd9 && first <= 0xdb)
+        {
+            return try parseString(data: data)
+        }
+        if (first >= 0x80 && first <= 0x8f) || (first >= 0xde && first <= 0xdf)
+        {
+            return try parseMap(data: data)
+        }
+        if (first >= 0x90 && first <= 0x9f) || (first >= 0xdc && first <= 0xdd)
+        {
+            return try parseArray(data: data)
+        }
+        if first >= 0xc4 && first <= 0xc6 {
+            return try parseBinary(data: data)
+        }
+        if first >= 0xd4 && first <= 0xde || first >= 0xc7 && first <= 0xc9 {
+            return try parseExtension(data: data)
+        }
+        switch first {
+        case 0xca:
+            return try parseFloat32(data: data.subdata(in: 1..<data.count))
+        case 0xcb:
+            return try parseFloat64(data: data.subdata(in: 1..<data.count))
+        case 0xc2:
+            return (MsgpackType.bool(false), data.subdata(in: 1..<data.count))
+        case 0xc3:
+            return (MsgpackType.bool(true), data.subdata(in: 1..<data.count))
+        case 0xc0:
+            return (MsgpackType.null, data.subdata(in: 1..<data.count))
+        default:
+            throw MsgpackDecodingError.decdoeWithUnexpectedMsgpackType(first)
+        }
+    }
+
+    private static func parseNumber(data: Data) throws -> (MsgpackType, Data) {
+        try assertLength(data: data, length: 1)
+        let first = data[0]
+        let remaining = data.subdata(in: 1..<data.count)
+        // Fixed positive int
+        if first >= 0x00 && first <= 0x7f {
+            let uint8 = UInt8(first)
+            return (MsgpackType.uint(UInt64(uint8)), remaining)
+        }
+        // Fixed negative int
+        if first >= 0xe0 && first <= 0xff {
+            let int8Data = data[..<1]
+            let int8: Int8 = int8Data.withUnsafeBytes { pointer in
+                return pointer.load(as: Int8.self)
+            }
+            return (MsgpackType.int(Int64(int8)), remaining)
+        }
+
+        switch first {
+        case 0xcc:  // UInt8
+            let (uint8, remaining) = try parseRawUInt8(data: remaining)
+            return (MsgpackType.uint(UInt64(uint8)), remaining)
+        case 0xcd:  // UInt16
+            let (uint16, remaining) = try parseRawUInt16(data: remaining)
+            return (MsgpackType.uint(UInt64(uint16)), remaining)
+        case 0xce:  // UInt32
+            let (uint32, remaining) = try parseRawUInt32(data: remaining)
+            return (MsgpackType.uint(UInt64(uint32)), remaining)
+        case 0xcf:  // UInt64
+            let (uint64, remaining) = try parseRawUInt64(data: remaining)
+            return (MsgpackType.uint(uint64), remaining)
+        case 0xd0:  //Int8
+            let (int8, remaining) = try parseRawInt8(data: remaining)
+            return (MsgpackType.int(Int64(int8)), remaining)
+        case 0xd1:  //Int16
+            let (int16, remaining) = try parseRawInt16(data: remaining)
+            return (MsgpackType.int(Int64(int16)), remaining)
+        case 0xd2:  //Int32
+            let (int32, remaining) = try parseRawInt32(data: remaining)
+            return (MsgpackType.int(Int64(int32)), remaining)
+        case 0xd3:  //Int64
+            let (int64, remaining) = try parseRawInt64(data: remaining)
+            return (MsgpackType.int(int64), remaining)
+        default:
+            throw MsgpackDecodingError.decdoeWithUnexpectedMsgpackType(first)
+        }
+    }
+
+    private static func parseFloat32(data: Data) throws -> (MsgpackType, Data) {
+        // float32 memory edianness is undefined. Use uint32 bits to init.
+        let (uint32, remaining) = try parseRawUInt32(data: data)
+        let float32 = Float32(bitPattern: uint32)
+        return (MsgpackType.float32(float32), remaining)
+    }
+
+    private static func parseFloat64(data: Data) throws -> (MsgpackType, Data) {
+        // float64 memory edianness is undefined. Use uint64 bits to init.
+        let (uint64, remaining) = try parseRawUInt64(data: data)
+        let float64 = Float64(bitPattern: uint64)
+        return (MsgpackType.float64(float64), remaining)
+    }
+
+    private static func parseString(data: Data) throws -> (MsgpackType, Data) {
+        try assertLength(data: data, length: 1)
+        var length: Int = 0
+        let first = data[0]
+        var remaining = data.subdata(in: 1..<data.count)
+        if first >= 0xa0 && first <= 0xbf {
+            length = Int(first & 0x1f)
+        } else {
+            switch first {
+            case 0xd9:  //Str8
+                var uint8: UInt8
+                (uint8, remaining) = try parseRawUInt8(data: remaining)
+                length = Int(uint8)
+            case 0xda:  //str16
+                var uint16: UInt16
+                (uint16, remaining) = try parseRawUInt16(data: remaining)
+                length = Int(uint16)
+            case 0xdb:  //str32
+                var uint32: UInt32
+                (uint32, remaining) = try parseRawUInt32(data: remaining)
+                guard uint32 <= Int.max else {
+                    throw MsgpackDecodingError.decodeStringTooLarge(uint32)
+                }
+                length = Int(uint32)
+            default:
+                throw MsgpackDecodingError.decdoeWithUnexpectedMsgpackType(
+                    first)
+            }
+        }
+        try assertLength(data: remaining, length: length)
+        guard let str = String(data: remaining[..<length], encoding: .utf8)
+        else {
+            throw MsgpackDecodingError.decodeStringError
+        }
+        return (
+            MsgpackType.string(str),
+            remaining.subdata(in: length..<remaining.count)
+        )
+    }
+
+    private static func parseBinary(data: Data) throws -> (MsgpackType, Data) {
+        try assertLength(data: data, length: 1)
+        var length: Int = 0
+        let first = data[0]
+        var remaining = data.subdata(in: 1..<data.count)
+        switch first {
+        case 0xc4:  //bin8
+            var uint8: UInt8
+            (uint8, remaining) = try parseRawUInt8(data: remaining)
+            length = Int(uint8)
+        case 0xc5:  //bin16
+            var uint16: UInt16
+            (uint16, remaining) = try parseRawUInt16(data: remaining)
+            length = Int(uint16)
+        case 0xc6:  //bin32
+            var uint32: UInt32
+            (uint32, remaining) = try parseRawUInt32(data: remaining)
+            guard uint32 <= Int.max else {
+                throw MsgpackDecodingError.decodeBinaryTooLarge(uint32)
+            }
+            length = Int(uint32)
+        default:
+            throw MsgpackDecodingError.decdoeWithUnexpectedMsgpackType(first)
+        }
+        try assertLength(data: remaining, length: length)
+        let binary = remaining.subdata(in: 0..<length)
+        return (
+            MsgpackType.bin(binary),
+            remaining.subdata(in: length..<remaining.count)
+        )
+    }
+
+    private static func parseMap(data: Data) throws -> (MsgpackType, Data) {
+        try assertLength(data: data, length: 1)
+        var length: Int = 0
+        let first = data[0]
+        var remaining = data.subdata(in: 1..<data.count)
+        if first >= 0x80 && first <= 0x8f {
+            length = Int(first & 0x0f)
+        } else {
+            switch first {
+            case 0xde:  //map16
+                var uint16: UInt16
+                (uint16, remaining) = try parseRawUInt16(data: remaining)
+                length = Int(uint16)
+            case 0xdf:  //map32
+                var uint32: UInt32
+                (uint32, remaining) = try parseRawUInt32(data: remaining)
+                guard uint32 <= Int.max else {
+                    throw MsgpackDecodingError.decodeMapTooLarge(uint32)
+                }
+                length = Int(uint32)
+            default:
+                throw MsgpackDecodingError.decdoeWithUnexpectedMsgpackType(
+                    first)
+            }
+        }
+
+        var map: [String: MsgpackType] = [:]
+        for _ in 0..<length {
+            var wrappedKey: MsgpackType
+            (wrappedKey, remaining) = try parseString(data: remaining)
+            guard case .string(let key) = wrappedKey else {
+                throw MsgpackDecodingError.decodeMapKeyNotString
+            }
+            var value: MsgpackType
+            (value, remaining) = try parse(data: remaining)
+            map[key] = value
+        }
+        return (MsgpackType.map(map), remaining)
+    }
+
+    private static func parseArray(data: Data) throws -> (MsgpackType, Data) {
+        try assertLength(data: data, length: 1)
+        var length: Int = 0
+        let first = data[0]
+        var remaining = data.subdata(in: 1..<data.count)
+        if first >= 0x90 && first <= 0x9f {
+            length = Int(first & 0x0f)
+        } else {
+            switch first {
+            case 0xdc:  //array16
+                var uint16: UInt16
+                (uint16, remaining) = try parseRawUInt16(data: remaining)
+                length = Int(uint16)
+            case 0xdd:  //array32
+                var uint32: UInt32
+                (uint32, remaining) = try parseRawUInt32(data: remaining)
+                guard uint32 <= Int.max else {
+                    throw MsgpackDecodingError.decodeArrayTooLarge(uint32)
+                }
+                length = Int(uint32)
+            default:
+                throw MsgpackDecodingError.decdoeWithUnexpectedMsgpackType(
+                    first)
+            }
+        }
+
+        var array: [MsgpackType] = []
+        array.reserveCapacity(length)
+        for _ in 0..<length {
+            var value: MsgpackType
+            (value, remaining) = try parse(data: remaining)
+            array.append(value)
+        }
+        return (MsgpackType.array(array), remaining)
+    }
+
+    private static func parseExtension(data: Data) throws -> (MsgpackType, Data)
+    {
+        try assertLength(data: data, length: 1)
+        let first = data[0]
+        var remaining = data.subdata(in: 1..<data.count)
+        var extType: Int8
+        var extLength: Int
+        switch first {
+        case 0xd4:
+            extLength = 1
+        case 0xd5:
+            extLength = 2
+        case 0xd6:
+            extLength = 4
+        case 0xd7:
+            extLength = 8
+        case 0xd8:
+            extLength = 16
+        case 0xc7:
+            var uint8: UInt8
+            (uint8, remaining) = try Self.parseRawUInt8(data: remaining)
+            extLength = Int(uint8)
+        case 0xc8:
+            var uint16: UInt16
+            (uint16, remaining) = try Self.parseRawUInt16(data: remaining)
+            extLength = Int(uint16)
+        case 0xc9:
+            var uint32: UInt32
+            (uint32, remaining) = try Self.parseRawUInt32(data: remaining)
+            guard UInt64(uint32) <= UInt64(Int.max) else {
+                throw MsgpackDecodingError.decodeExtensionTooLarge(uint32)
+            }
+            extLength = Int(uint32)
+        default:
+            throw MsgpackDecodingError.decdoeWithUnexpectedMsgpackType(first)
+        }
+
+        (extType, remaining) = try Self.parseRawInt8(data: remaining)
+        try assertLength(data: remaining, length: extLength)
+        let extData = remaining.subdata(in: 0..<extLength)
+        remaining = remaining.subdata(in: extLength..<remaining.count)
+
+        return (MsgpackType.ext(extType, extData), remaining)
+    }
+
+    fileprivate static func assertLength(data: Data, length: Int) throws {
+        guard data.count >= length else {
+            throw MsgpackDecodingError.corruptMessage
+        }
+    }
+
+    // MARK: Convert from MsgpackType to basic Swift type
+    func decode<T>(type: T.Type, codingPath: [CodingKey] = []) throws -> T?
+    where T: Decodable {
+        do {
+            switch type {
+            case is UInt.Type:
+                return try UInt(getUInt(max: UInt64(UInt.max))) as? T
+            case is UInt8.Type:
+                return try UInt8(getUInt(max: UInt64(UInt8.max))) as? T
+            case is UInt16.Type:
+                return try UInt16(getUInt(max: UInt64(UInt16.max))) as? T
+            case is UInt32.Type:
+                return try UInt32(getUInt(max: UInt64(UInt32.max))) as? T
+            case is UInt64.Type:
+                return try getUInt(max: UInt64.max) as? T
+
+            // Signed integers
+            case is Int.Type:
+                return try Int(getInt(min: Int64(Int.min), max: Int64(Int.max)))
+                    as? T
+            case is Int8.Type:
+                return try Int8(
+                    getInt(min: Int64(Int8.min), max: Int64(Int8.max))) as? T
+            case is Int16.Type:
+                return try Int16(
+                    getInt(min: Int64(Int16.min), max: Int64(Int16.max))) as? T
+            case is Int32.Type:
+                return try Int32(
+                    getInt(min: Int64(Int32.min), max: Int64(Int32.max))) as? T
+            case is Int64.Type:
+                return try getInt(min: Int64.min, max: Int64.max) as? T
+
+            // Float (Float16's decodable is implemented as Float32)
+            case is Float32.Type:
+                return Float32(try getFloat()) as? T
+            case is Float64.Type:
+                return try getFloat() as? T
+
+            // Bool
+            case is Bool.Type:
+                guard case let .bool(bool) = self else {
+                    throw MsgpackDecodingError.decodeTypeNotMatch
+                }
+                return bool as? T
+            // Data
+            case is Data.Type:
+                guard case let .bin(data) = self else {
+                    throw MsgpackDecodingError.decodeTypeNotMatch
+                }
+                return data as? T
+            // String
+            case is String.Type:
+                guard case let .string(string) = self else {
+                    throw MsgpackDecodingError.decodeTypeNotMatch
+                }
+                return string as? T
+            default:
+                return nil
+            }
+        } catch MsgpackDecodingError.decodeNumberWithInvalideRange(let number) {
+            throw DecodingError.typeMismatch(
+                T.self,
+                .init(
+                    codingPath: codingPath,
+                    debugDescription: "Can't convert \(number) to \(T.self)"))
+        } catch MsgpackDecodingError.decodeTypeNotMatch {
+            throw DecodingError.typeMismatch(
+                T.self,
+                .init(
+                    codingPath: codingPath,
+                    debugDescription:
+                        "Can't convert \(self.typeDescription) to \(T.self)"))
+        }
+    }
+
+    func getUInt(max: UInt64) throws -> UInt64 {
+        switch self {
+        case let .uint(uint64):
+            guard uint64 <= max else {
+                throw MsgpackDecodingError.decodeNumberWithInvalideRange(
+                    "\(uint64)")
+            }
+            return uint64
+        case let .int(int64):
+            guard int64 >= 0 && int64 <= max else {
+                throw MsgpackDecodingError.decodeNumberWithInvalideRange(
+                    "\(int64)")
+            }
+            return UInt64(int64)
+        default:
+            throw MsgpackDecodingError.decodeTypeNotMatch
+        }
+    }
+
+    func getInt(min: Int64, max: Int64) throws -> Int64 {
+        switch self {
+        case let .uint(uint64):
+            guard uint64 <= max else {
+                throw MsgpackDecodingError.decodeNumberWithInvalideRange(
+                    "\(uint64)")
+            }
+            return Int64(uint64)
+        case let .int(int64):
+            guard int64 >= min && int64 <= max else {
+                throw MsgpackDecodingError.decodeNumberWithInvalideRange(
+                    "\(int64)")
+            }
+            return Int64(int64)
+        default:
+            throw MsgpackDecodingError.decodeTypeNotMatch
+        }
+    }
+
+    func getFloat() throws -> Float64 {
+        switch self {
+        case let .float32(float32):
+            return Float64(float32)
+        case let .float64(Float64):
+            return Float64
+        default:
+            throw MsgpackDecodingError.decodeTypeNotMatch
+        }
+    }
+
+    fileprivate func isNil() -> Bool {
+        switch self {
+        case .null:
+            return true
+        default:
+            return false
+        }
+    }
+
+    // Utils methods
+    fileprivate static func parseRawUInt8(data: Data) throws -> (UInt8, Data) {
+        try MsgpackType.assertLength(data: data, length: 1)
+        let uint8Data = data[..<1]
+        let uint8 = uint8Data.withUnsafeBytes { pointer in
+            return pointer.load(as: UInt8.self)
+        }
+        let remaining = data.subdata(in: 1..<data.count)
+        return (uint8, remaining)
+    }
+
+    fileprivate static func parseRawUInt16(data: Data) throws -> (UInt16, Data)
+    {
+        try MsgpackType.assertLength(data: data, length: 2)
+        let uint16Data = data[..<2]
+        let uint16 = uint16Data.withUnsafeBytes { pointer in
+            return pointer.load(as: UInt16.self)
+        }.bigEndian
+        let remaining = data.subdata(in: 2..<data.count)
+        return (uint16, remaining)
+    }
+
+    fileprivate static func parseRawUInt32(data: Data) throws -> (UInt32, Data)
+    {
+        try MsgpackType.assertLength(data: data, length: 4)
+        let uint32Data = data[..<4]
+        let uint32 = uint32Data.withUnsafeBytes { pointer in
+            return pointer.load(as: UInt32.self)
+        }.bigEndian
+        let remaining = data.subdata(in: 4..<data.count)
+        return (uint32, remaining)
+    }
+
+    fileprivate static func parseRawUInt64(data: Data) throws -> (UInt64, Data)
+    {
+        try MsgpackType.assertLength(data: data, length: 8)
+        let uint64Data = data[..<8]
+        let uint64 = uint64Data.withUnsafeBytes { pointer in
+            return pointer.load(as: UInt64.self)
+        }.bigEndian
+        let remaining = data.subdata(in: 8..<data.count)
+        return (uint64, remaining)
+    }
+
+    fileprivate static func parseRawInt8(data: Data) throws -> (Int8, Data) {
+        try MsgpackType.assertLength(data: data, length: 1)
+        let int8Data = data[..<1]
+        let int8 = int8Data.withUnsafeBytes { pointer in
+            return pointer.load(as: Int8.self)
+        }.bigEndian
+        let remaining = data.subdata(in: 1..<data.count)
+        return (int8, remaining)
+    }
+
+    fileprivate static func parseRawInt16(data: Data) throws -> (Int16, Data) {
+        try MsgpackType.assertLength(data: data, length: 2)
+        let int16Data = data[..<2]
+        let int16 = int16Data.withUnsafeBytes { pointer in
+            return pointer.load(as: Int16.self)
+        }.bigEndian
+        let remaining = data.subdata(in: 2..<data.count)
+        return (int16, remaining)
+    }
+
+    fileprivate static func parseRawInt32(data: Data) throws -> (Int32, Data) {
+        try MsgpackType.assertLength(data: data, length: 4)
+        let int32Data = data[..<4]
+        let int32 = int32Data.withUnsafeBytes { pointer in
+            return pointer.load(as: Int32.self)
+        }.bigEndian
+        let remaining = data.subdata(in: 4..<data.count)
+        return (int32, remaining)
+    }
+
+    fileprivate static func parseRawInt64(data: Data) throws -> (Int64, Data) {
+        try MsgpackType.assertLength(data: data, length: 8)
+        let int64Data = data[..<8]
+        let int64 = int64Data.withUnsafeBytes { pointer in
+            return pointer.load(as: Int64.self)
+        }.bigEndian
+        let remaining = data.subdata(in: 8..<data.count)
+        return (int64, remaining)
+    }
+}
+
+// Decode Msgpacktimestamp from extension type -1
+extension MsgpackTimestamp: Decodable {
+    public init(from decoder: any Decoder) throws {
+        let extType = try decoder.getMsgpackExtType()
+        guard extType == -1 else {
+            throw DecodingError.typeMismatch(
+                MsgpackTimestamp.self,
+                .init(
+                    codingPath: decoder.codingPath,
+                    debugDescription:
+                        "The extension type is not -1 when decoding \(MsgpackTimestamp.self)"
+                ))
+        }
+        let extData = try decoder.getMsgpackExtData()
+        switch extData.count {
+        case 4:
+            let (uint32, _) = try MsgpackType.parseRawUInt32(data: extData)
+            self.seconds = Int64(uint32)
+            self.nanoseconds = 0
+        case 8:
+            let (uint64, _) = try MsgpackType.parseRawUInt64(data: extData)
+            self.nanoseconds = UInt32(uint64 >> 34)
+            self.seconds = Int64(uint64 & 0x0f_ffff_ffff)
+        case 12:
+            let (uint32, secondsData) = try MsgpackType.parseRawUInt32(
+                data: extData)
+            self.nanoseconds = uint32
+            let (int64, _) = try MsgpackType.parseRawInt64(data: secondsData)
+            self.seconds = int64
+        default:
+            throw MsgpackDecodingError.invalidTimeStamp
+        }
+    }
+}
+
+// MARK: Decoding error handling
+enum MsgpackDecodingError: Error, CustomStringConvertible {
+    // exposed error
+    case decdoeWithUnexpectedMsgpackType(UInt8)
+    case decodeMapKeyNotString
+    case corruptMessage
+    case decodeStringError
+    case decodeStringTooLarge(UInt32)
+    case decodeBinaryTooLarge(UInt32)
+    case decodeMapTooLarge(UInt32)
+    case decodeArrayTooLarge(UInt32)
+    case decodeExtensionTooLarge(UInt32)
+    case invalidTimeStamp
+
+    //  exception wrapped with context
+    case decodeNumberWithInvalideRange(String)
+    case decodeTypeNotMatch
+
+    // internal error
+    case decoderNotInitialized
+
+    var description: String {
+        switch self {
+        case .invalidTimeStamp:
+            return "The timestamp is not in correct format"
+        case .decdoeWithUnexpectedMsgpackType(let messageType):
+            return "\(messageType) is not valid messagepack type"
+        case .decodeMapKeyNotString:
+            return "The key must be String when decoding Map in Swift"
+        case .decodeStringError:
+            return "The given string is not in utf-8 format"
+        case .corruptMessage:
+            return "The given data was not valid messagepack message"
+        case .decodeStringTooLarge(let length):
+            return
+                "Reveived string with length \(length) which is larger than the supported max: \(Int.max)"
+        case .decodeBinaryTooLarge(let length):
+            return
+                "Reveived binary with length \(length) which is larger than the supported max: \(Int.max)"
+        case .decodeMapTooLarge(let count):
+            return
+                "Reveived map with \(count) keys which is larger than the supported max: \(Int.max)"
+        case .decodeArrayTooLarge(let count):
+            return
+                "Reveived array with \(count) elements which is larger than the supported max: \(Int.max)"
+        case .decodeExtensionTooLarge(let length):
+            return
+                "Reveived extension with length \(length) which is larger than the supported max: \(Int.max)"
+        default:
+            return ""
+        }
+    }
+}

--- a/Sources/SignalRClient/Protocols/msgpack/MsgpackEncoder.swift
+++ b/Sources/SignalRClient/Protocols/msgpack/MsgpackEncoder.swift
@@ -1,0 +1,600 @@
+import Foundation
+
+// MARK: Swift Encodable implementation. Encoder, KeyedContainer, UnkeyedContainer, SingleValueContainer
+class MsgpackEncoder: Encoder, MsgpackTypeConvertable {
+    var codingPath: [any CodingKey]
+    var userInfo: [CodingUserInfoKey: Any]
+    var msgpack: MsgpackTypeConvertable?
+
+    init(
+        codingPath: [any CodingKey] = [],
+        userInfo: [CodingUserInfoKey: Any] = [:]
+    ) {
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+    }
+
+    func encodeMsgpackExt(extType: Int8, extData: Data) throws {
+        self.msgpack = MsgpackType.ext(extType, extData)
+    }
+
+    func container<Key>(keyedBy key: Key.Type) -> KeyedEncodingContainer<Key>
+    where Key: CodingKey {
+        guard let container = self.msgpack else {
+            let container = MsgpackKeyedEncodingContainer<Key>(
+                codingPath: codingPath, userInfo: userInfo)
+            self.msgpack = container
+            return KeyedEncodingContainer(container)
+        }
+        // Assert. Panic if the container is of diffrent type
+        _ = container as! any KeyedEncodingContainerProtocol
+        let newContainer = (container as! MsgpackSwitchKeyProtocol).switchKey(
+            newKey: Key.self)
+        self.msgpack = newContainer
+        return KeyedEncodingContainer(newContainer)
+    }
+
+    func unkeyedContainer() -> any UnkeyedEncodingContainer {
+        guard let container = self.msgpack else {
+            let container = MsgpackUnkeyedEncodingContainer(
+                codingPath: codingPath, userInfo: userInfo)
+            self.msgpack = container
+            return container
+        }
+        // panic if the container is of diffrent type
+        return container as! UnkeyedEncodingContainer
+
+    }
+
+    func singleValueContainer() -> any SingleValueEncodingContainer {
+        guard let container = self.msgpack else {
+            let container = MsgpackSingleValueEncodingContainer(
+                codingPath: codingPath, userInfo: userInfo)
+            self.msgpack = container
+            return container
+        }
+        // panic if the container is of diffrent type
+        return container as! SingleValueEncodingContainer
+    }
+
+    func encode<T>(_ v: T) throws -> Data where T: Encodable {
+        var msgpackType = MsgpackType(v)
+        if msgpackType == nil {
+            try v.encode(to: self)
+            msgpackType = try? convertToMsgpackType()
+        }
+        guard let msgpackType = msgpackType else {
+            throw EncodingError.invalidValue(
+                type(of: v),
+                .init(
+                    codingPath: codingPath,
+                    debugDescription:
+                        "Top-level \(String(describing: T.self)) did not encode any values."
+                ))
+        }
+        self.msgpack = msgpackType
+        return try msgpackType.marshall()
+    }
+
+    func convertToMsgpackType() throws -> MsgpackType {
+        guard let msgpack = msgpack else {
+            throw MsgpackEncodingError.encoderNotIntilized
+        }
+        return try msgpack.convertToMsgpackType()
+    }
+}
+
+class MsgpackKeyedEncodingContainer<Key: CodingKey>:
+    KeyedEncodingContainerProtocol, MsgpackTypeConvertable,
+    MsgpackSwitchKeyProtocol
+{
+    private var holder: [String: MsgpackTypeConvertable] = [:]
+    private var userInfo: [CodingUserInfoKey: Any]
+    var codingPath: [any CodingKey]
+
+    init(codingPath: [any CodingKey], userInfo: [CodingUserInfoKey: Any]) {
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+    }
+
+    func convertToMsgpackType() throws -> MsgpackType {
+        return .map(try holder.mapValues { v in try v.convertToMsgpackType() })
+    }
+
+    func switchKey<NewKey: CodingKey>(newKey: NewKey.Type)
+        -> MsgpackKeyedEncodingContainer<NewKey>
+    {
+        let container = MsgpackKeyedEncodingContainer<NewKey>(
+            codingPath: codingPath, userInfo: userInfo)
+        container.holder = self.holder
+        return container
+    }
+
+    func encodeNil(forKey key: Key) throws {
+        holder[key.stringValue] = MsgpackType.null
+    }
+
+    func encode<T>(_ value: T, forKey key: Key) throws where T: Encodable {
+        guard let msgpackType = MsgpackType(value) else {
+            let encoder = initEncoder(key: key)
+            try value.encode(to: encoder)
+            return
+        }
+        holder[key.stringValue] = msgpackType
+    }
+
+    func nestedContainer<NestedKey>(
+        keyedBy keyType: NestedKey.Type, forKey key: Key
+    ) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+        let encoder = initEncoder(key: key)
+        return encoder.container(keyedBy: keyType)
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) -> any UnkeyedEncodingContainer
+    {
+        let encoder = initEncoder(key: key)
+        return encoder.unkeyedContainer()
+    }
+
+    func superEncoder() -> any Encoder {
+        return initEncoder(key: MsgpackCodingKey(stringValue: "super"))
+    }
+
+    func superEncoder(forKey key: Key) -> any Encoder {
+        return initEncoder(key: key)
+    }
+
+    private func initEncoder(key: CodingKey) -> MsgpackEncoder {
+        var codingPath = self.codingPath
+        codingPath.append(key)
+        let encoder = MsgpackEncoder(
+            codingPath: codingPath, userInfo: self.userInfo)
+        holder[key.stringValue] = encoder
+        return encoder
+    }
+}
+
+class MsgpackUnkeyedEncodingContainer: UnkeyedEncodingContainer,
+    MsgpackTypeConvertable
+{
+    private var holder: [MsgpackTypeConvertable] = []
+    private var userInfo: [CodingUserInfoKey: Any]
+    var codingPath: [any CodingKey]
+    var count: Int { holder.count }
+
+    init(codingPath: [any CodingKey], userInfo: [CodingUserInfoKey: Any]) {
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+    }
+
+    func convertToMsgpackType() throws -> MsgpackType {
+        return .array(try holder.map { e in try e.convertToMsgpackType() })
+    }
+
+    func encodeNil() throws {
+        holder.append(MsgpackType.null)
+    }
+
+    func encode<T>(_ value: T) throws where T: Encodable {
+        guard let msgpackType = MsgpackType(value) else {
+            let encoder = initEncoder()
+            try value.encode(to: encoder)
+            return
+        }
+        self.holder.append(msgpackType)
+    }
+
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type)
+        -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey
+    {
+        let encoder = initEncoder()
+        return KeyedEncodingContainer(encoder.container(keyedBy: keyType))
+    }
+
+    func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+        let encoder = initEncoder()
+        return encoder.unkeyedContainer()
+    }
+
+    func superEncoder() -> any Encoder {
+        return initEncoder()
+    }
+
+    private func initEncoder() -> MsgpackEncoder {
+        var codingPath = self.codingPath
+        codingPath.append(MsgpackCodingKey(intValue: holder.count))
+        let encoder = MsgpackEncoder(
+            codingPath: codingPath, userInfo: self.userInfo)
+        holder.append(encoder)
+        return encoder
+    }
+}
+
+class MsgpackSingleValueEncodingContainer: SingleValueEncodingContainer,
+    MsgpackTypeConvertable
+{
+    private var holder: MsgpackTypeConvertable?
+    private var userInfo: [CodingUserInfoKey: Any]
+    var codingPath: [any CodingKey]
+
+    init(codingPath: [any CodingKey], userInfo: [CodingUserInfoKey: Any]) {
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+    }
+
+    func encodeNil() throws {
+        holder = MsgpackType.null
+    }
+
+    func convertToMsgpackType() throws -> MsgpackType {
+        guard let holder = holder else {
+            return MsgpackType.null
+        }
+        return try holder.convertToMsgpackType()
+    }
+
+    func encode<T>(_ value: T) throws where T: Encodable {
+        guard let msgpackType = MsgpackType(value) else {
+            let encoder = MsgpackEncoder(
+                codingPath: codingPath, userInfo: self.userInfo)
+            try value.encode(to: encoder)
+            self.holder = encoder
+            return
+        }
+        self.holder = msgpackType
+    }
+}
+
+// MARK: internal protocols
+private protocol MsgpackSwitchKeyProtocol {
+    func switchKey<NewKey: CodingKey>(newKey: NewKey.Type)
+        -> MsgpackKeyedEncodingContainer<NewKey>
+}
+
+protocol MsgpackTypeConvertable {
+    func convertToMsgpackType() throws -> MsgpackType
+}
+
+// MARK: (Encoding Part) Intermediate type which implements messagepack protocol. Similar to JSonObject
+extension MsgpackType: MsgpackTypeConvertable {
+    // MARK: Convert basic Swift type to MsgpackType
+    init?<T>(_ value: T) where T: Encodable {
+        switch value {
+        case let number as Int:
+            self = .int(Int64(number))
+        case let number as Int8:
+            self = .int(Int64(number))
+        case let number as Int16:
+            self = .int(Int64(number))
+        case let number as Int32:
+            self = .int(Int64(number))
+        case let number as Int64:
+            self = .int(number)
+        case let number as UInt8:
+            self = .uint(UInt64(number))
+        case let number as UInt16:
+            self = .uint(UInt64(number))
+        case let number as UInt32:
+            self = .uint(UInt64(number))
+        case let number as UInt64:
+            self = .uint(number)
+        case let string as String:
+            self = .string(string)
+        case let data as Data:
+            self = .bin(data)
+        case let bool as Bool:
+            self = .bool(bool)
+        case let float32 as Float32:
+            self = .float32(float32)
+        case let float64 as Float64:
+            self = .float64(float64)
+        default:
+            // Leave other encodable types to Encodable protocol
+            return nil
+        }
+    }
+
+    func convertToMsgpackType() throws -> MsgpackType {
+        return self
+    }
+
+    // MARK: Convert MsgpackType to Data
+    func marshall() throws -> Data {
+        switch self {
+        case .int(let number):
+            return Self.encodeInt64(number)
+        case .uint(let number):
+            return Self.encodeUInt64(number)
+        case .float32(let float32):
+            return Self.encodeFloat32(float32)
+        case .float64(let float64):
+            return Self.encodeFloat64(float64)
+        case .bool(let bool):
+            return Self.encodeBool(bool)
+        case .string(let s):
+            return try Self.encodeString(s)
+        case .null:
+            return Self.encodeNil()
+        case .bin(let data):
+            return try Self.encodeData(data)
+        case .map(let m):
+            return try Self.encodeMap(m)
+        case .array(let a):
+            return try Self.encodeArray(a)
+        case .ext(let type, let data):
+            return try Self.encodeExt(type: type, data: data)
+        }
+    }
+
+    private static func encodeUInt64(_ v: UInt64) -> Data {
+        if v <= Int8.max {
+            var uint8 = UInt8(v)
+            return Data(bytes: &uint8, count: MemoryLayout<UInt8>.size)
+        }
+        if v <= UInt8.max {
+            var uint8 = UInt8(v)
+            return [0xcc] + Data(bytes: &uint8, count: MemoryLayout<UInt8>.size)
+        }
+        if v <= UInt16.max {
+            var uint16 = UInt16(v).bigEndian
+            return [0xcd]
+                + Data(bytes: &uint16, count: MemoryLayout<UInt16>.size)
+        }
+        if v <= UInt32.max {
+            var uint32 = UInt32(v).bigEndian
+            return [0xce]
+                + Data(bytes: &uint32, count: MemoryLayout<UInt32>.size)
+        }
+        var uint64 = v.bigEndian
+        return [0xcf] + Data(bytes: &uint64, count: MemoryLayout<UInt64>.size)
+    }
+
+    private static func encodeInt64(_ v: Int64) -> Data {
+        guard v < 0 else {
+            return Self.encodeUInt64(UInt64(v))
+        }
+        if v >= -(1 << 5) {
+            var int8 = Int8(v)
+            return Data(bytes: &int8, count: MemoryLayout<Int8>.size)
+        }
+        if v >= Int8.min {
+            var int8 = Int8(v)
+            return [0xd0] + Data(bytes: &int8, count: MemoryLayout<Int8>.size)
+        }
+        if v >= Int16.min {
+            var int16 = Int16(v).bigEndian
+            return [0xd1] + Data(bytes: &int16, count: MemoryLayout<Int16>.size)
+        }
+        if v >= Int32.min {
+            var int32 = Int32(v).bigEndian
+            return [0xd2] + Data(bytes: &int32, count: MemoryLayout<Int32>.size)
+        }
+        var int64 = v.bigEndian
+        return [0xd3] + Data(bytes: &int64, count: MemoryLayout<Int64>.size)
+    }
+
+    private static func encodeFloat32(_ v: Float32) -> Data {
+        var float32BigEdianbits = v.bitPattern.bigEndian
+        return [0xca]
+            + Data(
+                bytes: &float32BigEdianbits, count: MemoryLayout<Float32>.size)
+    }
+
+    private static func encodeFloat64(_ v: Float64) -> Data {
+        var float64BigEdianbits = v.bitPattern.bigEndian
+        return [0xcb]
+            + Data(
+                bytes: &float64BigEdianbits, count: MemoryLayout<Float64>.size)
+    }
+
+    private static func encodeString(_ v: String) throws -> Data {
+        let length = v.count
+        let content = v.data(using: .utf8)!
+        if length < 1 << 5 {
+            return [0xa0 | UInt8(length)] + content
+        }
+        if length <= UInt8.max {
+            return [0xd9, UInt8(length)] + content
+        }
+        if length <= UInt16.max  {
+            var uint16 = UInt16(length).bigEndian
+            return [0xda]
+                + Data(bytes: &uint16, count: MemoryLayout<UInt16>.size)
+                + content
+        }
+        if length <= UInt32.max {
+            var uint32 = UInt32(length).bigEndian
+            return [0xdb]
+                + Data(bytes: &uint32, count: MemoryLayout<UInt32>.size)
+                + content
+        }
+        throw MsgpackEncodingError.stringTooLarge
+    }
+
+    private static func encodeBool(_ v: Bool) -> Data {
+        return v ? Data([0xc3]) : Data([0xc2])
+    }
+
+    private static func encodeNil() -> Data {
+        return Data([0xc0])
+    }
+
+    private static func encodeData(_ v: Data) throws -> Data {
+        let length = v.count
+        var lengthPrefix: Data
+        if length <= UInt8.max {
+            var uint8 = UInt8(length)
+            lengthPrefix =
+                [0xc4] + Data(bytes: &uint8, count: MemoryLayout<UInt8>.size)
+        } else if length <= UInt16.max {
+            var uint16 = UInt16(length).bigEndian
+            lengthPrefix =
+                [0xc5] + Data(bytes: &uint16, count: MemoryLayout<UInt16>.size)
+        } else if length <= UInt32.max {
+            var uint32 = UInt32(length).bigEndian
+            lengthPrefix =
+                [0xc6] + Data(bytes: &uint32, count: MemoryLayout<UInt32>.size)
+        } else {
+            throw MsgpackEncodingError.dataTooLarge
+        }
+        return lengthPrefix + v
+    }
+
+    private static func encodeMap(_ v: [String: MsgpackType]) throws -> Data {
+        let length = v.count
+        var mapPrefix: Data
+        if length < 1 << 4 {
+            mapPrefix = Data([0x80 | UInt8(length)])
+        } else if length <= UInt16.max {
+            var uint16 = UInt16(length).bigEndian
+            mapPrefix =
+                [0xde] + Data(bytes: &uint16, count: MemoryLayout<UInt16>.size)
+        } else if length <= UInt32.max {
+            var uint32 = UInt32(length).bigEndian
+            mapPrefix =
+                [0xdf] + Data(bytes: &uint32, count: MemoryLayout<UInt32>.size)
+        } else {
+            throw MsgpackEncodingError.mapTooManyElements
+        }
+        var list: [Data] = []
+        var totalLength = mapPrefix.count
+        for (k, v) in v {
+            let kData = try Self.encodeString(k)
+            totalLength += kData.count
+            list.append(kData)
+            let vData = try v.marshall()
+            totalLength += vData.count
+            list.append(vData)
+        }
+        var result = Data(capacity: totalLength)
+        result.append(mapPrefix)
+        for v in list {
+            result.append(v)
+        }
+        return result
+    }
+
+    private static func encodeArray(_ v: [MsgpackType]) throws -> Data {
+        let length = v.count
+        var arrayPrefix: Data
+        if length < 1 << 4 {
+            arrayPrefix = Data([0x90 | UInt8(length)])
+        } else if length <= UInt16.max {
+            var uint16 = UInt16(length).bigEndian
+            arrayPrefix =
+                [0xdc] + Data(bytes: &uint16, count: MemoryLayout<UInt16>.size)
+        } else if length <= UInt32.max {
+            var uint32 = UInt32(length).bigEndian
+            arrayPrefix =
+                [0xdd] + Data(bytes: &uint32, count: MemoryLayout<UInt32>.size)
+        } else {
+            throw MsgpackEncodingError.arrayTooManyElements
+        }
+        var list: [Data] = []
+        var totalLength = arrayPrefix.count
+        for v in v {
+            let vData = try v.marshall()
+            totalLength += vData.count
+            list.append(vData)
+        }
+        var result = Data(capacity: totalLength)
+        result.append(arrayPrefix)
+        for v in list {
+            result.append(v)
+        }
+        return result
+    }
+
+    private static func encodeExt(type: Int8, data: Data) throws -> Data {
+        let length = data.count
+        var int8 = Int8(type)
+        let typeData = Data(bytes: &int8, count: MemoryLayout<Int8>.size)
+        if length == 1 {
+            return [0xd4] + typeData + data
+        }
+        if length == 2 {
+            return [0xd5] + typeData + data
+        }
+        if length == 4 {
+            return [0xd6] + typeData + data
+        }
+        if length == 8 {
+            return [0xd7] + typeData + data
+        }
+        if length == 16 {
+            return [0xd8] + typeData + data
+        }
+        if length <= UInt8.max {
+            return [0xc7, UInt8(length)] + typeData + data
+        }
+        if length <= UInt16.max {
+            var uint16 = UInt16(length).bigEndian
+            let uint16Data = Data(
+                bytes: &uint16, count: MemoryLayout<UInt16>.size)
+            return [0xc8] + uint16Data + typeData + data
+        }
+        if length <= UInt32.max {
+            var uint32 = UInt32(length).bigEndian
+            let uint32Data = Data(
+                bytes: &uint32, count: MemoryLayout<UInt32>.size)
+            return [0xc9] + uint32Data + typeData + data
+        }
+        throw MsgpackEncodingError.extensionTooLarge
+    }
+}
+
+// Encode Msgpacktimestamp to extension type -1
+extension MsgpackTimestamp: Encodable {
+    public func encode(to encoder: any Encoder) throws {
+        let nanoseconds = self.nanoseconds
+        let seconds = self.seconds
+        var data: Data
+        if nanoseconds == 0 && seconds >= 0 && seconds <= UInt32.max {
+            var secondsUInt32 = UInt32(seconds).bigEndian
+            data = Data(bytes: &secondsUInt32, count: MemoryLayout<UInt32>.size)
+        } else if seconds >= 0 && seconds < (UInt64(1)) << 34 {
+            let secondsUInt64 = UInt64(seconds).bigEndian
+            let nanoSecondsUInt64 = (UInt64(nanoseconds) << 34).bigEndian
+            var time = nanoSecondsUInt64 | secondsUInt64
+            data = Data(bytes: &time, count: MemoryLayout<UInt64>.size)
+        } else {
+            var secondsInt64 = seconds.bigEndian
+            var nanoSecondsUInt32 = UInt32(nanoseconds).bigEndian
+            data =
+                Data(
+                    bytes: &nanoSecondsUInt32, count: MemoryLayout<UInt32>.size)
+                + Data(bytes: &secondsInt64, count: MemoryLayout<Int64>.size)
+        }
+        return try encoder.encodeMsgpackExt(extType: -1, extData: data)
+    }
+}
+
+// MARK: Encoding error handling
+enum MsgpackEncodingError: Error, CustomStringConvertible {
+    // exposed exception
+    case dataTooLarge
+    case mapTooManyElements
+    case arrayTooManyElements
+    case stringTooLarge
+    case extensionTooLarge
+
+    // internal exception
+    case encoderNotIntilized
+
+    var description: String {
+        switch self {
+        case .dataTooLarge:
+            return "Messagpack can't encode binary larger than 4GB"
+        case .mapTooManyElements:
+            return "Messagpack can't encode map with more than 4G keys"
+        case .arrayTooManyElements:
+            return "Messagpack can't encode array with more than 4G elements"
+        case .stringTooLarge:
+            return "Messagpack can't encode string larger than 4GB"
+        case .extensionTooLarge:
+            return "Messagpack can't encode extension larger than 4GB"
+        default:
+            return ""
+        }
+    }
+}

--- a/Tests/SignalRClientTests/Msgpack/MsgpackDecoderTests.swift
+++ b/Tests/SignalRClientTests/Msgpack/MsgpackDecoderTests.swift
@@ -3,18 +3,18 @@ import XCTest
 @testable import SignalRClient
 
 class MsgpackDecoderTests: XCTestCase {
-    // MARK: Convert Data to MsgpackType
+    // MARK: Convert Data to MsgpackElement
     func testParseUInt() throws {
         let data: [UInt64] = [
             0, 0x7f, 0x80, 0xff, 0x100, 0xffff, 0x10000, 0xffff_ffff,
             0x1_0000_0000,
         ]
         for i in data {
-            let msgpackType = MsgpackType.uint(i)
-            let binary = try msgpackType.marshall()
-            let (decodeddType, remaining) = try MsgpackType.parse(data: binary)
+            let msgpackElement = MsgpackElement.uint(i)
+            let binary = try msgpackElement.marshall()
+            let (decodeddType, remaining) = try MsgpackElement.parse(data: binary)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decodeddType, msgpackType)
+            XCTAssertEqual(decodeddType, msgpackElement)
         }
     }
 
@@ -23,11 +23,11 @@ class MsgpackDecoderTests: XCTestCase {
             -0x20, -0x21, -0x80, -0x81, -0x8000, -0x8000, -0x10000, -0x8000,
         ]
         for i in data {
-            let msgpackType = MsgpackType.int(i)
-            let binary = try msgpackType.marshall()
-            let (decodeddType, remaining) = try MsgpackType.parse(data: binary)
+            let msgpackElement = MsgpackElement.int(i)
+            let binary = try msgpackElement.marshall()
+            let (decodeddType, remaining) = try MsgpackElement.parse(data: binary)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decodeddType, msgpackType)
+            XCTAssertEqual(decodeddType, msgpackElement)
         }
     }
 
@@ -43,32 +43,32 @@ class MsgpackDecoderTests: XCTestCase {
             0xd3, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
         ])
         for (k, v) in data {
-            let (decodeddType, remaining) = try MsgpackType.parse(data: v)
+            let (decodeddType, remaining) = try MsgpackElement.parse(data: v)
             XCTAssertEqual(remaining.count, 0)
-            let msgpackType = MsgpackType.int(k)
-            XCTAssertEqual(decodeddType, msgpackType)
+            let msgpackElement = MsgpackElement.int(k)
+            XCTAssertEqual(decodeddType, msgpackElement)
         }
     }
 
     func testParseFloat32() throws {
         let data: [Float32] = [0.0, 1.1 - 0.9]
         for i in data {
-            let msgpackType = MsgpackType.float32(i)
-            let binary = try msgpackType.marshall()
-            let (decodeddType, remaining) = try MsgpackType.parse(data: binary)
+            let msgpackElement = MsgpackElement.float32(i)
+            let binary = try msgpackElement.marshall()
+            let (decodeddType, remaining) = try MsgpackElement.parse(data: binary)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decodeddType, msgpackType)
+            XCTAssertEqual(decodeddType, msgpackElement)
         }
     }
 
     func testParseFloat64() throws {
         let data: [Float64] = [0.0, 1.1 - 0.9]
         for i in data {
-            let msgpackType = MsgpackType.float64(i)
-            let binary = try msgpackType.marshall()
-            let (decodeddType, remaining) = try MsgpackType.parse(data: binary)
+            let msgpackElement = MsgpackElement.float64(i)
+            let binary = try msgpackElement.marshall()
+            let (decodeddType, remaining) = try MsgpackElement.parse(data: binary)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decodeddType, msgpackType)
+            XCTAssertEqual(decodeddType, msgpackElement)
         }
     }
 
@@ -77,74 +77,74 @@ class MsgpackDecoderTests: XCTestCase {
             0, 1 << 5 - 1, 1 << 5, 1 << 8 - 1, 1 << 8, 1 << 16 - 1, 1 << 16,
         ]
         for length in data {
-            let msgpackType = MsgpackType.string(
+            let msgpackElement = MsgpackElement.string(
                 String(repeating: Character("a"), count: length))
-            let binary = try msgpackType.marshall()
-            let (decodedType, remaining) = try MsgpackType.parse(data: binary)
+            let binary = try msgpackElement.marshall()
+            let (decodedType, remaining) = try MsgpackElement.parse(data: binary)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decodedType, msgpackType)
+            XCTAssertEqual(decodedType, msgpackElement)
         }
     }
 
     func testParseNil() throws {
-        let msgpackType = MsgpackType.null
-        let binary = try msgpackType.marshall()
-        let (decodedType, remaining) = try MsgpackType.parse(data: binary)
+        let msgpackElement = MsgpackElement.null
+        let binary = try msgpackElement.marshall()
+        let (decodedType, remaining) = try MsgpackElement.parse(data: binary)
         XCTAssertEqual(remaining.count, 0)
-        XCTAssertEqual(decodedType, msgpackType)
+        XCTAssertEqual(decodedType, msgpackElement)
     }
 
     func testParseBool() throws {
         let data: [Bool] = [true, false]
         for b in data {
-            let msgpackType = MsgpackType.bool(b)
-            let binary = try msgpackType.marshall()
-            let (decodedType, remaining) = try MsgpackType.parse(data: binary)
+            let msgpackElement = MsgpackElement.bool(b)
+            let binary = try msgpackElement.marshall()
+            let (decodedType, remaining) = try MsgpackElement.parse(data: binary)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decodedType, msgpackType)
+            XCTAssertEqual(decodedType, msgpackElement)
         }
     }
 
     func testParseData() throws {
         let data = [0, 1 << 8 - 1, 1 << 8, 1 << 16 - 1, 1 << 16]
         for length in data {
-            let msgpackType = MsgpackType.bin(
+            let msgpackElement = MsgpackElement.bin(
                 Data(repeating: UInt8(2), count: length))
-            let binary = try msgpackType.marshall()
-            let (decodedType, remaining) = try MsgpackType.parse(data: binary)
+            let binary = try msgpackElement.marshall()
+            let (decodedType, remaining) = try MsgpackElement.parse(data: binary)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decodedType, msgpackType)
+            XCTAssertEqual(decodedType, msgpackElement)
         }
     }
 
     func testParseMap() throws {
         let data = [0, 1 << 4 - 1, 1 << 4, 1 << 16 - 1, 1 << 16]
         for i in data {
-            var map: [String: MsgpackType] = [:]
+            var map: [String: MsgpackElement] = [:]
             for i in 0..<i {
-                map[String(i)] = MsgpackType.bool(true)
+                map[String(i)] = MsgpackElement.bool(true)
             }
-            let msgpackType = MsgpackType.map(map)
-            let content = try msgpackType.marshall()
-            let (decoded, remaining) = try MsgpackType.parse(data: content)
+            let msgpackElement = MsgpackElement.map(map)
+            let content = try msgpackElement.marshall()
+            let (decoded, remaining) = try MsgpackElement.parse(data: content)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decoded, msgpackType)
+            XCTAssertEqual(decoded, msgpackElement)
         }
     }
 
     func testParseArray() throws {
         let data = [0, 1 << 4 - 1, 1 << 4, 1 << 16 - 1, 1 << 16]
         for i in data {
-            var array: [MsgpackType] = []
+            var array: [MsgpackElement] = []
             array.reserveCapacity(i)
             for _ in 0..<i {
-                array.append(MsgpackType.bool(true))
+                array.append(MsgpackElement.bool(true))
             }
-            let msgpackType = MsgpackType.array(array)
-            let content = try msgpackType.marshall()
-            let (decoded, remaining) = try MsgpackType.parse(data: content)
+            let msgpackElement = MsgpackElement.array(array)
+            let content = try msgpackElement.marshall()
+            let (decoded, remaining) = try MsgpackElement.parse(data: content)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decoded, msgpackType)
+            XCTAssertEqual(decoded, msgpackElement)
         }
     }
 
@@ -155,257 +155,257 @@ class MsgpackDecoderTests: XCTestCase {
         ]
         for len in data {
             let extData = Data(repeating: 1, count: len)
-            let msgpackType = MsgpackType.ext(-1, extData)
-            let content = try msgpackType.marshall()
-            let (decoded, remaining) = try MsgpackType.parse(data: content)
+            let msgpackElement = MsgpackElement.ext(-1, extData)
+            let content = try msgpackElement.marshall()
+            let (decoded, remaining) = try MsgpackElement.parse(data: content)
             XCTAssertEqual(remaining.count, 0)
-            XCTAssertEqual(decoded, msgpackType)
+            XCTAssertEqual(decoded, msgpackElement)
         }
     }
 
-    // MARK: Convert MsgpackType to basic Swift types
+    // MARK: Convert MsgpackElement to basic Swift types
     func testDecodeUInt8() throws {
         XCTAssertEqual(
-            try MsgpackType.int(Int64(UInt8.min)).decode(type: UInt8.self),
+            try MsgpackElement.int(Int64(UInt8.min)).decode(type: UInt8.self),
             UInt8.min)
         XCTAssertEqual(
-            try MsgpackType.int(Int64(UInt8.max)).decode(type: UInt8.self),
+            try MsgpackElement.int(Int64(UInt8.max)).decode(type: UInt8.self),
             UInt8.max)
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(UInt8.max) + 1).decode(type: UInt8.self))
+            try MsgpackElement.int(Int64(UInt8.max) + 1).decode(type: UInt8.self))
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(-1)).decode(type: UInt8.self))
+            try MsgpackElement.int(Int64(-1)).decode(type: UInt8.self))
 
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(UInt8.min)).decode(type: UInt8.self),
+            try MsgpackElement.uint(UInt64(UInt8.min)).decode(type: UInt8.self),
             UInt8.min)
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(UInt8.max)).decode(type: UInt8.self),
+            try MsgpackElement.uint(UInt64(UInt8.max)).decode(type: UInt8.self),
             UInt8.max)
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(UInt8.max) + 1).decode(type: UInt8.self)
+            try MsgpackElement.uint(UInt64(UInt8.max) + 1).decode(type: UInt8.self)
         )
     }
 
     func testDecodeUInt16() throws {
         XCTAssertEqual(
-            try MsgpackType.int(Int64(UInt16.min)).decode(type: UInt16.self),
+            try MsgpackElement.int(Int64(UInt16.min)).decode(type: UInt16.self),
             UInt16.min)
         XCTAssertEqual(
-            try MsgpackType.int(Int64(UInt16.max)).decode(type: UInt16.self),
+            try MsgpackElement.int(Int64(UInt16.max)).decode(type: UInt16.self),
             UInt16.max)
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(UInt16.max) + 1).decode(type: UInt16.self)
+            try MsgpackElement.int(Int64(UInt16.max) + 1).decode(type: UInt16.self)
         )
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(-1)).decode(type: UInt16.self))
+            try MsgpackElement.int(Int64(-1)).decode(type: UInt16.self))
 
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(UInt16.min)).decode(type: UInt16.self),
+            try MsgpackElement.uint(UInt64(UInt16.min)).decode(type: UInt16.self),
             UInt16.min)
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(UInt16.max)).decode(type: UInt16.self),
+            try MsgpackElement.uint(UInt64(UInt16.max)).decode(type: UInt16.self),
             UInt16.max)
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(UInt16.max) + 1).decode(
+            try MsgpackElement.uint(UInt64(UInt16.max) + 1).decode(
                 type: UInt16.self))
     }
 
     func testDecodeUInt32() throws {
         XCTAssertEqual(
-            try MsgpackType.int(Int64(UInt32.min)).decode(type: UInt32.self),
+            try MsgpackElement.int(Int64(UInt32.min)).decode(type: UInt32.self),
             UInt32.min)
         XCTAssertEqual(
-            try MsgpackType.int(Int64(UInt32.max)).decode(type: UInt32.self),
+            try MsgpackElement.int(Int64(UInt32.max)).decode(type: UInt32.self),
             UInt32.max)
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(UInt32.max) + 1).decode(type: UInt32.self)
+            try MsgpackElement.int(Int64(UInt32.max) + 1).decode(type: UInt32.self)
         )
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(-1)).decode(type: UInt32.self))
+            try MsgpackElement.int(Int64(-1)).decode(type: UInt32.self))
 
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(UInt32.min)).decode(type: UInt32.self),
+            try MsgpackElement.uint(UInt64(UInt32.min)).decode(type: UInt32.self),
             UInt32.min)
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(UInt32.max)).decode(type: UInt32.self),
+            try MsgpackElement.uint(UInt64(UInt32.max)).decode(type: UInt32.self),
             UInt32.max)
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(UInt32.max) + 1).decode(
+            try MsgpackElement.uint(UInt64(UInt32.max) + 1).decode(
                 type: UInt32.self))
     }
 
     func testDecodeUInt64() throws {
         XCTAssertEqual(
-            try MsgpackType.int(Int64(UInt64.min)).decode(type: UInt64.self),
+            try MsgpackElement.int(Int64(UInt64.min)).decode(type: UInt64.self),
             UInt64.min)
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int64.max)).decode(type: UInt64.self),
+            try MsgpackElement.int(Int64(Int64.max)).decode(type: UInt64.self),
             UInt64(Int64.max))
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(-1)).decode(type: UInt64.self))
+            try MsgpackElement.int(Int64(-1)).decode(type: UInt64.self))
 
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(UInt64.min)).decode(type: UInt64.self),
+            try MsgpackElement.uint(UInt64(UInt64.min)).decode(type: UInt64.self),
             UInt64.min)
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(UInt64.max)).decode(type: UInt64.self),
+            try MsgpackElement.uint(UInt64(UInt64.max)).decode(type: UInt64.self),
             UInt64.max)
     }
 
     func testDecodeInt8() throws {
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int8.min)).decode(type: Int8.self),
+            try MsgpackElement.int(Int64(Int8.min)).decode(type: Int8.self),
             Int8.min)
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int8.max)).decode(type: Int8.self),
+            try MsgpackElement.int(Int64(Int8.max)).decode(type: Int8.self),
             Int8.max)
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(Int8.max) + 1).decode(type: Int8.self))
+            try MsgpackElement.int(Int64(Int8.max) + 1).decode(type: Int8.self))
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(Int8.min) - 1).decode(type: Int8.self))
+            try MsgpackElement.int(Int64(Int8.min) - 1).decode(type: Int8.self))
 
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(Int8.max)).decode(type: Int8.self),
+            try MsgpackElement.uint(UInt64(Int8.max)).decode(type: Int8.self),
             Int8.max)
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(0)).decode(type: Int8.self), 0)
+            try MsgpackElement.uint(UInt64(0)).decode(type: Int8.self), 0)
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int8.max) + 1).decode(type: Int8.self))
+            try MsgpackElement.uint(UInt64(Int8.max) + 1).decode(type: Int8.self))
     }
 
     func testDecodeInt16() throws {
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int16.min)).decode(type: Int16.self),
+            try MsgpackElement.int(Int64(Int16.min)).decode(type: Int16.self),
             Int16.min)
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int16.max)).decode(type: Int16.self),
+            try MsgpackElement.int(Int64(Int16.max)).decode(type: Int16.self),
             Int16.max)
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(Int16.max) + 1).decode(type: Int16.self))
+            try MsgpackElement.int(Int64(Int16.max) + 1).decode(type: Int16.self))
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(Int16.min) - 1).decode(type: Int16.self))
+            try MsgpackElement.int(Int64(Int16.min) - 1).decode(type: Int16.self))
 
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(0)).decode(type: Int16.self), 0)
+            try MsgpackElement.uint(UInt64(0)).decode(type: Int16.self), 0)
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(Int16.max)).decode(type: Int16.self),
+            try MsgpackElement.uint(UInt64(Int16.max)).decode(type: Int16.self),
             Int16.max)
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int16.max) + 1).decode(type: Int16.self)
+            try MsgpackElement.uint(UInt64(Int16.max) + 1).decode(type: Int16.self)
         )
     }
 
     func testDecodeInt32() throws {
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int32.min)).decode(type: Int32.self),
+            try MsgpackElement.int(Int64(Int32.min)).decode(type: Int32.self),
             Int32.min)
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int32.max)).decode(type: Int32.self),
+            try MsgpackElement.int(Int64(Int32.max)).decode(type: Int32.self),
             Int32.max)
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(Int32.max) + 1).decode(type: Int32.self))
+            try MsgpackElement.int(Int64(Int32.max) + 1).decode(type: Int32.self))
         XCTAssertThrowsError(
-            try MsgpackType.int(Int64(Int32.min) - 1).decode(type: Int32.self))
+            try MsgpackElement.int(Int64(Int32.min) - 1).decode(type: Int32.self))
 
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(0)).decode(type: Int32.self), 0)
+            try MsgpackElement.uint(UInt64(0)).decode(type: Int32.self), 0)
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(Int32.max)).decode(type: Int32.self),
+            try MsgpackElement.uint(UInt64(Int32.max)).decode(type: Int32.self),
             Int32.max)
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int32.max) + 1).decode(type: Int32.self)
+            try MsgpackElement.uint(UInt64(Int32.max) + 1).decode(type: Int32.self)
         )
     }
 
     func testDecodeInt64() throws {
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int64.min)).decode(type: Int64.self),
+            try MsgpackElement.int(Int64(Int64.min)).decode(type: Int64.self),
             Int64.min)
         XCTAssertEqual(
-            try MsgpackType.int(Int64(Int64.max)).decode(type: Int64.self),
+            try MsgpackElement.int(Int64(Int64.max)).decode(type: Int64.self),
             Int64.max)
 
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(0)).decode(type: Int64.self), 0)
+            try MsgpackElement.uint(UInt64(0)).decode(type: Int64.self), 0)
         XCTAssertEqual(
-            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Int64.self),
+            try MsgpackElement.uint(UInt64(Int64.max)).decode(type: Int64.self),
             Int64.max)
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int64.max) + 1).decode(type: Int64.self)
+            try MsgpackElement.uint(UInt64(Int64.max) + 1).decode(type: Int64.self)
         )
     }
 
     func testDecodeBool() throws {
-        XCTAssertEqual(try MsgpackType.bool(true).decode(type: Bool.self), true)
+        XCTAssertEqual(try MsgpackElement.bool(true).decode(type: Bool.self), true)
         XCTAssertEqual(
-            try MsgpackType.bool(false).decode(type: Bool.self), false)
+            try MsgpackElement.bool(false).decode(type: Bool.self), false)
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Bool.self))
+            try MsgpackElement.uint(UInt64(Int64.max)).decode(type: Bool.self))
     }
 
     func testDecodeString() throws {
         XCTAssertEqual(
-            try MsgpackType.string("abc").decode(type: String.self), "abc")
-        XCTAssertEqual(try MsgpackType.string("").decode(type: String.self), "")
+            try MsgpackElement.string("abc").decode(type: String.self), "abc")
+        XCTAssertEqual(try MsgpackElement.string("").decode(type: String.self), "")
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int64.max)).decode(type: String.self))
+            try MsgpackElement.uint(UInt64(Int64.max)).decode(type: String.self))
     }
 
     func testDecodeData() throws {
         XCTAssertEqual(
-            try MsgpackType.bin(Data([0x81])).decode(type: Data.self),
+            try MsgpackElement.bin(Data([0x81])).decode(type: Data.self),
             Data([0x81]))
         XCTAssertEqual(
-            try MsgpackType.bin(Data()).decode(type: Data.self), Data())
+            try MsgpackElement.bin(Data()).decode(type: Data.self), Data())
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Data.self))
+            try MsgpackElement.uint(UInt64(Int64.max)).decode(type: Data.self))
     }
 
     func testDecodeFloat16() throws {
         let decoder = MsgpackDecoder()
-        var msgpackType = MsgpackType.float32(Float32(1.0))
-        try decoder.loadMsgpackType(msgpackType)
+        var msgpackElement = MsgpackElement.float32(Float32(1.0))
+        try decoder.loadMsgpackElement(from: msgpackElement)
         var float16 = try Float16.init(from: decoder)
         XCTAssertEqual(float16, Float16(1.0))
-        msgpackType = MsgpackType.float64(Float64(1.0))
-        try decoder.loadMsgpackType(msgpackType)
+        msgpackElement = MsgpackElement.float64(Float64(1.0))
+        try decoder.loadMsgpackElement(from: msgpackElement)
         float16 = try Float16.init(from: decoder)
         XCTAssertEqual(float16, Float16(1.0))
 
-        msgpackType = MsgpackType.uint(UInt64(Int64.max))
-        try decoder.loadMsgpackType(msgpackType)
+        msgpackElement = MsgpackElement.uint(UInt64(Int64.max))
+        try decoder.loadMsgpackElement(from: msgpackElement)
         XCTAssertThrowsError(try Float16.init(from: decoder))
     }
 
     func testDecodeFloat32() throws {
         XCTAssertEqual(
-            try MsgpackType.float32(Float32(1.0)).decode(type: Float32.self),
+            try MsgpackElement.float32(Float32(1.0)).decode(type: Float32.self),
             Float32(1.0))
         XCTAssertEqual(
-            try MsgpackType.float64(Float64(1.0)).decode(type: Float32.self),
+            try MsgpackElement.float64(Float64(1.0)).decode(type: Float32.self),
             Float32(1.0))
         XCTAssertEqual(
-            try MsgpackType.float64(Float64(1.1)).decode(type: Float32.self),
+            try MsgpackElement.float64(Float64(1.1)).decode(type: Float32.self),
             Float32(1.1))
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Float32.self))
+            try MsgpackElement.uint(UInt64(Int64.max)).decode(type: Float32.self))
     }
 
     func testDecodeFloat64() throws {
         XCTAssertEqual(
-            try MsgpackType.float32(Float32(1.0)).decode(type: Float64.self),
+            try MsgpackElement.float32(Float32(1.0)).decode(type: Float64.self),
             Float64(1.0))
         // Lose precision. But it should not throw
         XCTAssertNotEqual(
-            try MsgpackType.float32(Float32(1.1)).decode(type: Float64.self),
+            try MsgpackElement.float32(Float32(1.1)).decode(type: Float64.self),
             Float64(1.1))
 
         XCTAssertEqual(
-            try MsgpackType.float64(Float64(1.0)).decode(type: Float64.self),
+            try MsgpackElement.float64(Float64(1.0)).decode(type: Float64.self),
             Float64(1.0))
         XCTAssertThrowsError(
-            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Float64.self))
+            try MsgpackElement.uint(UInt64(Int64.max)).decode(type: Float64.self))
     }
 
     // MARK: MsgpackDecoder
@@ -445,10 +445,10 @@ class MsgpackDecoderTests: XCTestCase {
         let encoder = MsgpackEncoder()
         let example = Example1()
         let encodedData = try encoder.encode(example)
-        let msgpackType = try encoder.convertToMsgpackType()
+        let msgpackElement = try encoder.convertToMsgpackElement()
 
         let decoder = MsgpackDecoder()
-        try decoder.loadMsgpackType(msgpackType)
+        try decoder.loadMsgpackElement(from: msgpackElement)
         let decodedExample1 = try Example1.init(from: decoder)
 
         XCTAssertEqual(example, decodedExample1)
@@ -480,18 +480,18 @@ class MsgpackDecoderTests: XCTestCase {
     }
 
     func testDecode2() throws {
-        var map: [String: MsgpackType] = [:]
-        map["Key1"] = MsgpackType.int(Int64(123))
-        var nestedMap: [String: MsgpackType] = [:]
-        nestedMap["nestedKey"] = MsgpackType.string("abc")
-        map["Key2"] = MsgpackType.map(nestedMap)
-        let array: [MsgpackType] = [MsgpackType.bin(Data([0xab]))]
-        map["Key3"] = MsgpackType.array(array)
-        map["Key4"] = MsgpackType.null
+        var map: [String: MsgpackElement] = [:]
+        map["Key1"] = MsgpackElement.int(Int64(123))
+        var nestedMap: [String: MsgpackElement] = [:]
+        nestedMap["nestedKey"] = MsgpackElement.string("abc")
+        map["Key2"] = MsgpackElement.map(nestedMap)
+        let array: [MsgpackElement] = [MsgpackElement.bin(Data([0xab]))]
+        map["Key3"] = MsgpackElement.array(array)
+        map["Key4"] = MsgpackElement.null
 
-        let msgpackType = MsgpackType.map(map)
+        let msgpackElement = MsgpackElement.map(map)
         let decoder = MsgpackDecoder()
-        try decoder.loadMsgpackType(msgpackType)
+        try decoder.loadMsgpackElement(from: msgpackElement)
         let decodedExample = try Example2.init(from: decoder)
         XCTAssertEqual(decodedExample.Key1, 123)
         let expectedMap: [String: String] = ["nestedKey": "abc"]
@@ -534,9 +534,9 @@ class MsgpackDecoderTests: XCTestCase {
         example.parent = "abc"
         example.child = "def"
         let data = try encoder.encode(example)
-        let msgpackType = try encoder.convertToMsgpackType()
+        let msgpackElement = try encoder.convertToMsgpackElement()
         let decoder = MsgpackDecoder()
-        try decoder.loadMsgpackType(msgpackType)
+        try decoder.loadMsgpackElement(from: msgpackElement)
         let decodedExample = try InherienceWithSameContainerExample.init(
             from: decoder)
         XCTAssertEqual(decodedExample.parent, "abc")
@@ -578,9 +578,9 @@ class MsgpackDecoderTests: XCTestCase {
         example.parent = "abc"
         example.child = "def"
         let data = try encoder.encode(example)
-        let msgpackType = try encoder.convertToMsgpackType()
+        let msgpackElement = try encoder.convertToMsgpackElement()
         let decoder = MsgpackDecoder()
-        try decoder.loadMsgpackType(msgpackType)
+        try decoder.loadMsgpackElement(from: msgpackElement)
         let decodedExample = try KeyedSuperExample.init(from: decoder)
         XCTAssertEqual(decodedExample.parent, "abc")
         XCTAssertEqual(decodedExample.child, "def")

--- a/Tests/SignalRClientTests/Msgpack/MsgpackDecoderTests.swift
+++ b/Tests/SignalRClientTests/Msgpack/MsgpackDecoderTests.swift
@@ -1,0 +1,814 @@
+import XCTest
+
+@testable import SignalRClient
+
+class MsgpackDecoderTests: XCTestCase {
+    // MARK: Convert Data to MsgpackType
+    func testParseUInt() throws {
+        let data: [UInt64] = [
+            0, 0x7f, 0x80, 0xff, 0x100, 0xffff, 0x10000, 0xffff_ffff,
+            0x1_0000_0000,
+        ]
+        for i in data {
+            let msgpackType = MsgpackType.uint(i)
+            let binary = try msgpackType.marshall()
+            let (decodeddType, remaining) = try MsgpackType.parse(data: binary)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decodeddType, msgpackType)
+        }
+    }
+
+    func testParseNegativeInt() throws {
+        let data: [Int64] = [
+            -0x20, -0x21, -0x80, -0x81, -0x8000, -0x8000, -0x10000, -0x8000,
+        ]
+        for i in data {
+            let msgpackType = MsgpackType.int(i)
+            let binary = try msgpackType.marshall()
+            let (decodeddType, remaining) = try MsgpackType.parse(data: binary)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decodeddType, msgpackType)
+        }
+    }
+
+    func testParseIntNotNegative() throws {
+        var data: [Int64: Data] = [:]
+        data[0] = Data([0xd0, 0x00])
+        data[1 << 7 - 1] = Data([0xd0, 0x7f])
+        data[1 << 7] = Data([0xd1, 0x00, 0x80])
+        data[1 << 15 - 1] = Data([0xd1, 0x7f, 0xff])
+        data[1 << 15] = Data([0xd2, 0x00, 0x00, 0x80, 0x00])
+        data[1 << 31 - 1] = Data([0xd2, 0x7f, 0xff, 0xff, 0xff])
+        data[1 << 31] = Data([
+            0xd3, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
+        ])
+        for (k, v) in data {
+            let (decodeddType, remaining) = try MsgpackType.parse(data: v)
+            XCTAssertEqual(remaining.count, 0)
+            let msgpackType = MsgpackType.int(k)
+            XCTAssertEqual(decodeddType, msgpackType)
+        }
+    }
+
+    func testParseFloat32() throws {
+        let data: [Float32] = [0.0, 1.1 - 0.9]
+        for i in data {
+            let msgpackType = MsgpackType.float32(i)
+            let binary = try msgpackType.marshall()
+            let (decodeddType, remaining) = try MsgpackType.parse(data: binary)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decodeddType, msgpackType)
+        }
+    }
+
+    func testParseFloat64() throws {
+        let data: [Float64] = [0.0, 1.1 - 0.9]
+        for i in data {
+            let msgpackType = MsgpackType.float64(i)
+            let binary = try msgpackType.marshall()
+            let (decodeddType, remaining) = try MsgpackType.parse(data: binary)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decodeddType, msgpackType)
+        }
+    }
+
+    func testParseString() throws {
+        let data: [Int] = [
+            0, 1 << 5 - 1, 1 << 5, 1 << 8 - 1, 1 << 8, 1 << 16 - 1, 1 << 16,
+        ]
+        for length in data {
+            let msgpackType = MsgpackType.string(
+                String(repeating: Character("a"), count: length))
+            let binary = try msgpackType.marshall()
+            let (decodedType, remaining) = try MsgpackType.parse(data: binary)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decodedType, msgpackType)
+        }
+    }
+
+    func testParseNil() throws {
+        let msgpackType = MsgpackType.null
+        let binary = try msgpackType.marshall()
+        let (decodedType, remaining) = try MsgpackType.parse(data: binary)
+        XCTAssertEqual(remaining.count, 0)
+        XCTAssertEqual(decodedType, msgpackType)
+    }
+
+    func testParseBool() throws {
+        let data: [Bool] = [true, false]
+        for b in data {
+            let msgpackType = MsgpackType.bool(b)
+            let binary = try msgpackType.marshall()
+            let (decodedType, remaining) = try MsgpackType.parse(data: binary)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decodedType, msgpackType)
+        }
+    }
+
+    func testParseData() throws {
+        let data = [0, 1 << 8 - 1, 1 << 8, 1 << 16 - 1, 1 << 16]
+        for length in data {
+            let msgpackType = MsgpackType.bin(
+                Data(repeating: UInt8(2), count: length))
+            let binary = try msgpackType.marshall()
+            let (decodedType, remaining) = try MsgpackType.parse(data: binary)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decodedType, msgpackType)
+        }
+    }
+
+    func testParseMap() throws {
+        let data = [0, 1 << 4 - 1, 1 << 4, 1 << 16 - 1, 1 << 16]
+        for i in data {
+            var map: [String: MsgpackType] = [:]
+            for i in 0..<i {
+                map[String(i)] = MsgpackType.bool(true)
+            }
+            let msgpackType = MsgpackType.map(map)
+            let content = try msgpackType.marshall()
+            let (decoded, remaining) = try MsgpackType.parse(data: content)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decoded, msgpackType)
+        }
+    }
+
+    func testParseArray() throws {
+        let data = [0, 1 << 4 - 1, 1 << 4, 1 << 16 - 1, 1 << 16]
+        for i in data {
+            var array: [MsgpackType] = []
+            array.reserveCapacity(i)
+            for _ in 0..<i {
+                array.append(MsgpackType.bool(true))
+            }
+            let msgpackType = MsgpackType.array(array)
+            let content = try msgpackType.marshall()
+            let (decoded, remaining) = try MsgpackType.parse(data: content)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decoded, msgpackType)
+        }
+    }
+
+    func testDecodeExt() throws {
+        let data: [Int] = [
+            1, 2, 4, 8, 16, 0, 1 << 8 - 1, 1 << 8, 1 << 16 - 1, 1 << 16,
+            Int(UInt32.max),
+        ]
+        for len in data {
+            let extData = Data(repeating: 1, count: len)
+            let msgpackType = MsgpackType.ext(-1, extData)
+            let content = try msgpackType.marshall()
+            let (decoded, remaining) = try MsgpackType.parse(data: content)
+            XCTAssertEqual(remaining.count, 0)
+            XCTAssertEqual(decoded, msgpackType)
+        }
+    }
+
+    // MARK: Convert MsgpackType to basic Swift types
+    func testDecodeUInt8() throws {
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(UInt8.min)).decode(type: UInt8.self),
+            UInt8.min)
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(UInt8.max)).decode(type: UInt8.self),
+            UInt8.max)
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(UInt8.max) + 1).decode(type: UInt8.self))
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(-1)).decode(type: UInt8.self))
+
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(UInt8.min)).decode(type: UInt8.self),
+            UInt8.min)
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(UInt8.max)).decode(type: UInt8.self),
+            UInt8.max)
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(UInt8.max) + 1).decode(type: UInt8.self)
+        )
+    }
+
+    func testDecodeUInt16() throws {
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(UInt16.min)).decode(type: UInt16.self),
+            UInt16.min)
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(UInt16.max)).decode(type: UInt16.self),
+            UInt16.max)
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(UInt16.max) + 1).decode(type: UInt16.self)
+        )
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(-1)).decode(type: UInt16.self))
+
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(UInt16.min)).decode(type: UInt16.self),
+            UInt16.min)
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(UInt16.max)).decode(type: UInt16.self),
+            UInt16.max)
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(UInt16.max) + 1).decode(
+                type: UInt16.self))
+    }
+
+    func testDecodeUInt32() throws {
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(UInt32.min)).decode(type: UInt32.self),
+            UInt32.min)
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(UInt32.max)).decode(type: UInt32.self),
+            UInt32.max)
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(UInt32.max) + 1).decode(type: UInt32.self)
+        )
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(-1)).decode(type: UInt32.self))
+
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(UInt32.min)).decode(type: UInt32.self),
+            UInt32.min)
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(UInt32.max)).decode(type: UInt32.self),
+            UInt32.max)
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(UInt32.max) + 1).decode(
+                type: UInt32.self))
+    }
+
+    func testDecodeUInt64() throws {
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(UInt64.min)).decode(type: UInt64.self),
+            UInt64.min)
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int64.max)).decode(type: UInt64.self),
+            UInt64(Int64.max))
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(-1)).decode(type: UInt64.self))
+
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(UInt64.min)).decode(type: UInt64.self),
+            UInt64.min)
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(UInt64.max)).decode(type: UInt64.self),
+            UInt64.max)
+    }
+
+    func testDecodeInt8() throws {
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int8.min)).decode(type: Int8.self),
+            Int8.min)
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int8.max)).decode(type: Int8.self),
+            Int8.max)
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(Int8.max) + 1).decode(type: Int8.self))
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(Int8.min) - 1).decode(type: Int8.self))
+
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(Int8.max)).decode(type: Int8.self),
+            Int8.max)
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(0)).decode(type: Int8.self), 0)
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int8.max) + 1).decode(type: Int8.self))
+    }
+
+    func testDecodeInt16() throws {
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int16.min)).decode(type: Int16.self),
+            Int16.min)
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int16.max)).decode(type: Int16.self),
+            Int16.max)
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(Int16.max) + 1).decode(type: Int16.self))
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(Int16.min) - 1).decode(type: Int16.self))
+
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(0)).decode(type: Int16.self), 0)
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(Int16.max)).decode(type: Int16.self),
+            Int16.max)
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int16.max) + 1).decode(type: Int16.self)
+        )
+    }
+
+    func testDecodeInt32() throws {
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int32.min)).decode(type: Int32.self),
+            Int32.min)
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int32.max)).decode(type: Int32.self),
+            Int32.max)
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(Int32.max) + 1).decode(type: Int32.self))
+        XCTAssertThrowsError(
+            try MsgpackType.int(Int64(Int32.min) - 1).decode(type: Int32.self))
+
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(0)).decode(type: Int32.self), 0)
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(Int32.max)).decode(type: Int32.self),
+            Int32.max)
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int32.max) + 1).decode(type: Int32.self)
+        )
+    }
+
+    func testDecodeInt64() throws {
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int64.min)).decode(type: Int64.self),
+            Int64.min)
+        XCTAssertEqual(
+            try MsgpackType.int(Int64(Int64.max)).decode(type: Int64.self),
+            Int64.max)
+
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(0)).decode(type: Int64.self), 0)
+        XCTAssertEqual(
+            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Int64.self),
+            Int64.max)
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int64.max) + 1).decode(type: Int64.self)
+        )
+    }
+
+    func testDecodeBool() throws {
+        XCTAssertEqual(try MsgpackType.bool(true).decode(type: Bool.self), true)
+        XCTAssertEqual(
+            try MsgpackType.bool(false).decode(type: Bool.self), false)
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Bool.self))
+    }
+
+    func testDecodeString() throws {
+        XCTAssertEqual(
+            try MsgpackType.string("abc").decode(type: String.self), "abc")
+        XCTAssertEqual(try MsgpackType.string("").decode(type: String.self), "")
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int64.max)).decode(type: String.self))
+    }
+
+    func testDecodeData() throws {
+        XCTAssertEqual(
+            try MsgpackType.bin(Data([0x81])).decode(type: Data.self),
+            Data([0x81]))
+        XCTAssertEqual(
+            try MsgpackType.bin(Data()).decode(type: Data.self), Data())
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Data.self))
+    }
+
+    func testDecodeFloat16() throws {
+        let decoder = MsgpackDecoder()
+        var msgpackType = MsgpackType.float32(Float32(1.0))
+        try decoder.loadMsgpackType(msgpackType)
+        var float16 = try Float16.init(from: decoder)
+        XCTAssertEqual(float16, Float16(1.0))
+        msgpackType = MsgpackType.float64(Float64(1.0))
+        try decoder.loadMsgpackType(msgpackType)
+        float16 = try Float16.init(from: decoder)
+        XCTAssertEqual(float16, Float16(1.0))
+
+        msgpackType = MsgpackType.uint(UInt64(Int64.max))
+        try decoder.loadMsgpackType(msgpackType)
+        XCTAssertThrowsError(try Float16.init(from: decoder))
+    }
+
+    func testDecodeFloat32() throws {
+        XCTAssertEqual(
+            try MsgpackType.float32(Float32(1.0)).decode(type: Float32.self),
+            Float32(1.0))
+        XCTAssertEqual(
+            try MsgpackType.float64(Float64(1.0)).decode(type: Float32.self),
+            Float32(1.0))
+        XCTAssertEqual(
+            try MsgpackType.float64(Float64(1.1)).decode(type: Float32.self),
+            Float32(1.1))
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Float32.self))
+    }
+
+    func testDecodeFloat64() throws {
+        XCTAssertEqual(
+            try MsgpackType.float32(Float32(1.0)).decode(type: Float64.self),
+            Float64(1.0))
+        // Lose precision. But it should not throw
+        XCTAssertNotEqual(
+            try MsgpackType.float32(Float32(1.1)).decode(type: Float64.self),
+            Float64(1.1))
+
+        XCTAssertEqual(
+            try MsgpackType.float64(Float64(1.0)).decode(type: Float64.self),
+            Float64(1.0))
+        XCTAssertThrowsError(
+            try MsgpackType.uint(UInt64(Int64.max)).decode(type: Float64.self))
+    }
+
+    // MARK: MsgpackDecoder
+    private struct Example1: Codable, Equatable {
+        var int: Int
+        var intNil: Int?
+        var bool: Bool
+        var boolNil: Bool?
+        var string: String
+        var data: Data
+        var float32: Float32
+        var float64: Float64
+        var map1: [String: String]
+        var map2: [String: Bool]
+        var map3: [String: [String: Bool]]
+        var array1: [Int?]
+        var array2: [[Int?]]
+        var date: Date
+        init() {
+            self.int = 2
+            self.boolNil = true
+            self.bool = true
+            self.string = "123"
+            self.data = Data([0x90])
+            self.float32 = 1.1
+            self.float64 = 1.1
+            self.map1 = [:]
+            self.map2 = ["a": true]
+            self.map3 = ["b": map2]
+            self.array1 = [1, 2, nil, 4]
+            self.array2 = [self.array1]
+            self.date = Date(timeIntervalSince1970: 100.1)
+        }
+    }
+
+    func testDecode1() throws {
+        let encoder = MsgpackEncoder()
+        let example = Example1()
+        let encodedData = try encoder.encode(example)
+        let msgpackType = try encoder.convertToMsgpackType()
+
+        let decoder = MsgpackDecoder()
+        try decoder.loadMsgpackType(msgpackType)
+        let decodedExample1 = try Example1.init(from: decoder)
+
+        XCTAssertEqual(example, decodedExample1)
+
+        let decodedExample2 = try decoder.decode(
+            Example1.self, from: encodedData)
+        XCTAssertEqual(example, decodedExample2)
+    }
+
+    private struct Example2: Decodable {
+        var Key1: Int
+        var Key2: [String: String]
+        var Key3: [Data]
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: Keys.self)
+            self.Key1 = try container.decode(Int.self, forKey: Keys.Key1)
+            self.Key2 = try container.decode(
+                [String: String].self, forKey: .Key2)
+            self.Key3 = try container.decode([Data].self, forKey: .Key3)
+        }
+
+        enum Keys: CodingKey {
+            case Key1
+            case Key2
+            case Key3
+
+            case nestedKey1
+        }
+    }
+
+    func testDecode2() throws {
+        var map: [String: MsgpackType] = [:]
+        map["Key1"] = MsgpackType.int(Int64(123))
+        var nestedMap: [String: MsgpackType] = [:]
+        nestedMap["nestedKey"] = MsgpackType.string("abc")
+        map["Key2"] = MsgpackType.map(nestedMap)
+        let array: [MsgpackType] = [MsgpackType.bin(Data([0xab]))]
+        map["Key3"] = MsgpackType.array(array)
+        map["Key4"] = MsgpackType.null
+
+        let msgpackType = MsgpackType.map(map)
+        let decoder = MsgpackDecoder()
+        try decoder.loadMsgpackType(msgpackType)
+        let decodedExample = try Example2.init(from: decoder)
+        XCTAssertEqual(decodedExample.Key1, 123)
+        let expectedMap: [String: String] = ["nestedKey": "abc"]
+        XCTAssertEqual(decodedExample.Key2, expectedMap)
+        XCTAssertEqual(decodedExample.Key3, [Data([0xab])])
+    }
+
+    private class BaseClassExample: Codable {
+        var parent: String = "123"
+    }
+
+    private class InherienceWithSameContainerExample: BaseClassExample {
+        var child: String = "456"
+
+        override init() {
+            super.init()
+        }
+
+        override func encode(to encoder: any Encoder) throws {
+            try super.encode(to: encoder)
+            // Switching to a KeyedContainer with different key type
+            var container = encoder.container(keyedBy: Keys.self)
+            try container.encode(child, forKey: .child)
+        }
+
+        required init(from decoder: any Decoder) throws {
+            try super.init(from: decoder)
+            let container = try decoder.container(keyedBy: Keys.self)
+            self.child = try container.decode(String.self, forKey: .child)
+        }
+
+        enum Keys: CodingKey {
+            case child
+        }
+    }
+
+    func testInherienceUsingSameTopContainer() throws {  // Undocumented behavior. Keep aligh with the jsonEncoder
+        let encoder = MsgpackEncoder()
+        let example = InherienceWithSameContainerExample()
+        example.parent = "abc"
+        example.child = "def"
+        let data = try encoder.encode(example)
+        let msgpackType = try encoder.convertToMsgpackType()
+        let decoder = MsgpackDecoder()
+        try decoder.loadMsgpackType(msgpackType)
+        let decodedExample = try InherienceWithSameContainerExample.init(
+            from: decoder)
+        XCTAssertEqual(decodedExample.parent, "abc")
+        XCTAssertEqual(decodedExample.child, "def")
+        let decodedExample2 = try decoder.decode(
+            InherienceWithSameContainerExample.self, from: data)
+        XCTAssertEqual(decodedExample2.parent, "abc")
+        XCTAssertEqual(decodedExample2.child, "def")
+    }
+
+    private class KeyedSuperExample: BaseClassExample {
+        var child: String = ""
+
+        override init() {
+            super.init()
+        }
+        override func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: Keys.self)
+            try container.encode(child, forKey: .child)
+            let encoder = container.superEncoder()
+            try super.encode(to: encoder)
+        }
+
+        required init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: Keys.self)
+            self.child = try container.decode(String.self, forKey: .child)
+            let superDecoder = try container.superDecoder()
+            try super.init(from: superDecoder)
+        }
+
+        enum Keys: CodingKey {
+            case child
+        }
+    }
+
+    func testKeyedInherience() throws {
+        let encoder = MsgpackEncoder()
+        let example = KeyedSuperExample()
+        example.parent = "abc"
+        example.child = "def"
+        let data = try encoder.encode(example)
+        let msgpackType = try encoder.convertToMsgpackType()
+        let decoder = MsgpackDecoder()
+        try decoder.loadMsgpackType(msgpackType)
+        let decodedExample = try KeyedSuperExample.init(from: decoder)
+        XCTAssertEqual(decodedExample.parent, "abc")
+        XCTAssertEqual(decodedExample.child, "def")
+        let decodedExample2 = try decoder.decode(
+            KeyedSuperExample.self, from: data)
+        XCTAssertEqual(decodedExample2.parent, "abc")
+        XCTAssertEqual(decodedExample2.child, "def")
+    }
+
+    // MARK: Extension
+    func testDecodeTimestamp() throws {
+        let data: [Double] = [
+            0, -0.5, -1.5, 1.5, Double(UInt32.max), Double(UInt32.max) + 1,
+            Double(UInt64(1) << 34 - 1), Double(UInt64(1) << 34),
+        ]
+        for time in data {
+            let seconds = Int64(time.rounded(FloatingPointRoundingRule.down))
+            let nanoseconds = UInt32(
+                ((time - Double(seconds)) * 1_000_000_000).rounded(
+                    FloatingPointRoundingRule.down))
+            let timestamp = MsgpackTimestamp(
+                seconds: seconds, nanoseconds: nanoseconds)
+            let encoder = MsgpackEncoder()
+            let content = try encoder.encode(timestamp)
+            let decoder = MsgpackDecoder()
+            let timestamp2 = try decoder.decode(
+                MsgpackTimestamp.self, from: content)
+            XCTAssertEqual(timestamp, timestamp2)
+        }
+    }
+
+    // MARK: User Info
+    struct UserInfoExample: Codable {
+        init() {
+        }
+
+        func encode(to encoder: any Encoder) throws {
+            var container1 = encoder.container(keyedBy: Keys.self)
+            let superEncoder = container1.superEncoder()
+            _ = superEncoder.singleValueContainer()
+            let superEncoder2 = container1.superEncoder(forKey: .Key1)
+            var container3 = superEncoder2.unkeyedContainer()
+            let superEncoder3 = container3.superEncoder()
+            _ = superEncoder3.singleValueContainer()
+        }
+
+        init(from decoder: any Decoder) throws {
+            AsserUserInfo(decoder.userInfo)
+            let container1 = try decoder.container(keyedBy: Keys.self)
+            let superDecoder = try container1.superDecoder()
+            AsserUserInfo(superDecoder.userInfo)
+            _ = try superDecoder.singleValueContainer()
+            let superDecoder2 = try container1.superDecoder(forKey: .Key1)
+            AsserUserInfo(superDecoder2.userInfo)
+            var container3 = try superDecoder2.unkeyedContainer()
+            let superDecoder3 = try container3.superDecoder()
+            AsserUserInfo(superDecoder3.userInfo)
+            _ = try superDecoder3.singleValueContainer()
+        }
+
+        enum Keys: CodingKey {
+            case Key1
+        }
+
+        func AsserUserInfo(_ userInfo: [CodingUserInfoKey: Any]) {
+            XCTAssertEqual(userInfo.count, 1)
+            let key = CodingUserInfoKey(rawValue: "key")!
+            XCTAssertEqual(userInfo[key] as! String, "value")
+        }
+    }
+
+    func testUserInfo() throws {
+        var userInfo: [CodingUserInfoKey: Any] = [:]
+        let key = CodingUserInfoKey(rawValue: "key")!
+        userInfo[key] = "value"
+        let encoder = MsgpackEncoder(userInfo: userInfo)
+        let example = UserInfoExample()
+        let data = try encoder.encode(example)
+        let decoder = MsgpackDecoder(userInfo: userInfo)
+        _ = try decoder.decode(UserInfoExample.self, from: data)
+    }
+
+    struct CodingKeyExample: Codable {
+        init() {
+        }
+
+        func encode(to encoder: any Encoder) throws {
+            var container1 = encoder.container(keyedBy: Keys.self)
+            let superEncoder = container1.superEncoder()
+            _ = superEncoder.singleValueContainer()
+            let superEncoder2 = container1.superEncoder(forKey: .superKey)
+            _ = superEncoder2.singleValueContainer()
+            var container2 = container1.nestedContainer(
+                keyedBy: Keys.self, forKey: .Key1)
+            var container3 = container2.nestedUnkeyedContainer(forKey: .Key2)
+            _ = container3.nestedUnkeyedContainer()
+        }
+
+        init(from decoder: any Decoder) throws {
+            XCTAssertEqual(decoder.codingPath.count, 0)
+            let container1 = try decoder.container(keyedBy: Keys.self)
+            XCTAssertEqual(container1.codingPath.count, 0)
+
+            let superDecoder = try container1.superDecoder()
+            XCTAssertEqual(superDecoder.codingPath.count, 1)
+            XCTAssertEqual(
+                superDecoder.codingPath[0] as! MsgpackCodingKey,
+                MsgpackCodingKey(stringValue: "super"))
+
+            let superSingleValueContainer =
+                try superDecoder.singleValueContainer()
+            XCTAssertEqual(superSingleValueContainer.codingPath.count, 1)
+            XCTAssertEqual(
+                superSingleValueContainer.codingPath[0] as! MsgpackCodingKey,
+                MsgpackCodingKey(stringValue: "super"))
+
+            let superDecoder2 = try container1.superDecoder(forKey: .superKey)
+            XCTAssertEqual(superDecoder2.codingPath.count, 1)
+            XCTAssertEqual(superDecoder2.codingPath[0] as! Keys, Keys.superKey)
+
+            let superSingleValueContainer2 =
+                try superDecoder2.singleValueContainer()
+            XCTAssertEqual(superSingleValueContainer2.codingPath.count, 1)
+            XCTAssertEqual(
+                superSingleValueContainer2.codingPath[0] as! Keys, Keys.superKey
+            )
+
+            let container2 = try container1.nestedContainer(
+                keyedBy: Keys.self, forKey: .Key1)
+            XCTAssertEqual(container2.codingPath.count, 1)
+            XCTAssertEqual(container2.codingPath[0] as! Keys, Keys.Key1)
+
+            var container3 = try container2.nestedUnkeyedContainer(
+                forKey: .Key2)
+            XCTAssertEqual(container3.codingPath.count, 2)
+            XCTAssertEqual(container3.codingPath[0] as! Keys, Keys.Key1)
+            XCTAssertEqual(container3.codingPath[1] as! Keys, Keys.Key2)
+
+            let container4 = try container3.nestedUnkeyedContainer()
+            XCTAssertEqual(container4.codingPath.count, 3)
+            XCTAssertEqual(container4.codingPath[0] as! Keys, Keys.Key1)
+            XCTAssertEqual(container4.codingPath[1] as! Keys, Keys.Key2)
+            XCTAssertEqual(
+                container4.codingPath[2] as! MsgpackCodingKey,
+                MsgpackCodingKey(intValue: 0))
+        }
+
+        enum Keys: CodingKey {
+            case Key1, Key2, superKey
+        }
+    }
+
+    func testCodingKey() throws {
+        let example = CodingKeyExample()
+        let encoder = MsgpackEncoder()
+        let data = try encoder.encode(example)
+
+        let decoder = MsgpackDecoder()
+        _ = try decoder.decode(CodingKeyExample.self, from: data)
+    }
+
+    // MARK: Container properties
+    struct UnkeyedContainerCountExample: Codable {
+        init() {
+        }
+
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.unkeyedContainer()
+            try container.encode(true)
+            _ = container.superEncoder().singleValueContainer()
+        }
+        init(from decoder: any Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+            XCTAssertEqual(container.count, 2)
+            XCTAssertEqual(container.currentIndex, 0)
+            XCTAssertEqual(container.isAtEnd, false)
+            XCTAssertEqual(try container.decodeNil(), false)
+            XCTAssertEqual(container.count, 2)
+            XCTAssertEqual(container.currentIndex, 0)
+            XCTAssertEqual(container.isAtEnd, false)
+            let bool = try container.decode(Bool.self)
+            XCTAssertEqual(bool, true)
+            XCTAssertEqual(container.count, 2)
+            XCTAssertEqual(container.currentIndex, 1)
+            XCTAssertEqual(container.isAtEnd, false)
+            _ = try container.superDecoder().singleValueContainer()
+            XCTAssertEqual(container.count, 2)
+            XCTAssertEqual(container.currentIndex, 2)
+            XCTAssertEqual(container.isAtEnd, true)
+        }
+    }
+
+    func testUnkeyedContainerCount() throws {
+        let example = UnkeyedContainerCountExample()
+        let encoder = MsgpackEncoder()
+        let data = try encoder.encode(example)
+
+        let decoder = MsgpackDecoder()
+        _ = try decoder.decode(UnkeyedContainerCountExample.self, from: data)
+    }
+
+    struct KeyedContainerExample: Codable {
+        init() {
+        }
+
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: Keys.self)
+            try container.encode(true, forKey: .Key1)
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: Keys.self)
+            XCTAssertEqual(container.contains(.Key1), true)
+            XCTAssertEqual(container.contains(.Key2), false)
+            XCTAssertEqual(container.allKeys.count, 1)
+            XCTAssertEqual(container.allKeys[0], .Key1)
+        }
+
+        enum Keys: CodingKey {
+            case Key1, Key2
+        }
+    }
+
+    func testKeyedContainerKeys() throws {
+        let encoder = MsgpackEncoder()
+        let example = KeyedContainerExample()
+        let data = try encoder.encode(example)
+        let decoder = MsgpackDecoder()
+        _ = try decoder.decode(KeyedContainerExample.self, from: data)
+    }
+}

--- a/Tests/SignalRClientTests/Msgpack/MsgpackEncoderTests.swift
+++ b/Tests/SignalRClientTests/Msgpack/MsgpackEncoderTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import MessagePacker
 import XCTest
 
 @testable import SignalRClient

--- a/Tests/SignalRClientTests/Msgpack/MsgpackEncoderTests.swift
+++ b/Tests/SignalRClientTests/Msgpack/MsgpackEncoderTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import SignalRClient
 
 class MsgpackEncoderTests: XCTestCase {
-    // MARK: Convert MsgpackType to Data
+    // MARK: Convert MsgpackElement to Data
     func testEncodeUInt() throws {
         var data: [UInt64: Data] = [:]
         data[0x00] = Data([0x00])
@@ -19,7 +19,7 @@ class MsgpackEncoderTests: XCTestCase {
             0xcf, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
         ])
         for (uint64, expected) in data {
-            let result = try MsgpackType.uint(uint64).marshall()
+            let result = try MsgpackElement.uint(uint64).marshall()
             XCTAssertEqual(result, expected)
         }
     }
@@ -39,7 +39,7 @@ class MsgpackEncoderTests: XCTestCase {
         data[0x00] = Data([0x00])
         data[0x7f] = Data([0x7f])
         for (int64, expected) in data {
-            let result = try MsgpackType.int(int64).marshall()
+            let result = try MsgpackElement.int(int64).marshall()
             XCTAssertEqual(result, expected)
         }
     }
@@ -50,7 +50,7 @@ class MsgpackEncoderTests: XCTestCase {
         data[1.1] = Data([0xca, 0x3f, 0x8c, 0xcc, 0xcd])
         data[-0.9] = Data([0xca, 0xbf, 0x66, 0x66, 0x66])
         for (float32, expected) in data {
-            let result = try MsgpackType.float32(float32).marshall()
+            let result = try MsgpackElement.float32(float32).marshall()
             XCTAssertEqual(result, expected)
         }
     }
@@ -63,7 +63,7 @@ class MsgpackEncoderTests: XCTestCase {
             0xcb, 0xbf, 0xec, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcd,
         ])
         for (float64, expected) in data {
-            let result = try MsgpackType.float64(float64).marshall()
+            let result = try MsgpackElement.float64(float64).marshall()
             XCTAssertEqual(result, expected)
         }
     }
@@ -84,7 +84,7 @@ class MsgpackEncoderTests: XCTestCase {
             + Data(repeating: 0x61, count: 1 << 16)
         for (length, expected) in data {
             let string = String(repeating: Character("a"), count: length)
-            let result = try MsgpackType.string(string).marshall()
+            let result = try MsgpackElement.string(string).marshall()
             XCTAssertEqual(result, expected)
         }
     }
@@ -94,14 +94,14 @@ class MsgpackEncoderTests: XCTestCase {
         data[true] = Data([0xc3])
         data[false] = Data([0xc2])
         for (bool, expected) in data {
-            let result = try MsgpackType.bool(bool).marshall()
+            let result = try MsgpackElement.bool(bool).marshall()
             XCTAssertEqual(result, expected)
         }
     }
 
     func testEncodeNil() throws {
         let expected = Data([0xc0])
-        let result = try MsgpackType.null.marshall()
+        let result = try MsgpackElement.null.marshall()
         XCTAssertEqual(result, expected)
     }
 
@@ -119,70 +119,70 @@ class MsgpackEncoderTests: XCTestCase {
             + Data(repeating: UInt8(1), count: 1 << 16)
         for (length, expected) in data {
             let data = Data(repeating: UInt8(1), count: length)
-            let result = try MsgpackType.bin(data).marshall()
+            let result = try MsgpackElement.bin(data).marshall()
             XCTAssertEqual(result, expected)
         }
     }
 
     func testEncodeMap() throws {
-        var map: [String: MsgpackType] = [:]
-        var result = try MsgpackType.map(map).marshall()
+        var map: [String: MsgpackElement] = [:]
+        var result = try MsgpackElement.map(map).marshall()
         XCTAssertEqual(result, Data([0x80]))
         for i in 0..<1 << 4 - 1 {
-            map[String(i)] = MsgpackType.bool(true)
+            map[String(i)] = MsgpackElement.bool(true)
         }
-        result = try MsgpackType.map(map).marshall()
+        result = try MsgpackElement.map(map).marshall()
         XCTAssertEqual(result.count, 51)
         XCTAssertEqual(result[0], 0x8f)
 
         map.removeAll()
         for i in 0..<1 << 4 {
-            map[String(i)] = MsgpackType.bool(true)
+            map[String(i)] = MsgpackElement.bool(true)
         }
-        result = try MsgpackType.map(map).marshall()
+        result = try MsgpackElement.map(map).marshall()
         XCTAssertEqual(result.count, 57)
         XCTAssertEqual(result[0...2], Data([0xde, 0x00, 0x10]))
 
         map.removeAll()
         for i in 0..<1 << 16 - 1 {
-            map[String(i)] = MsgpackType.bool(true)
+            map[String(i)] = MsgpackElement.bool(true)
         }
-        result = try MsgpackType.map(map).marshall()
+        result = try MsgpackElement.map(map).marshall()
         XCTAssertEqual(result.count, 447638)
         XCTAssertEqual(result[0...2], Data([0xde, 0xff, 0xff]))
 
         map.removeAll()
         for i in 0..<1 << 16 {
-            map[String(i)] = MsgpackType.bool(true)
+            map[String(i)] = MsgpackElement.bool(true)
         }
-        result = try MsgpackType.map(map).marshall()
+        result = try MsgpackElement.map(map).marshall()
         XCTAssertEqual(result.count, 447647)
         XCTAssertEqual(result[0...4], Data([0xdf, 0x00, 0x01, 0x00, 0x00]))
     }
 
     func testEncodeArray() throws {
-        var data: [MsgpackType] = []
-        var result = try MsgpackType.array(data).marshall()
+        var data: [MsgpackElement] = []
+        var result = try MsgpackElement.array(data).marshall()
         XCTAssertEqual(result, Data([0x90]))
 
-        data = [MsgpackType](repeating: .bool(true), count: 1 << 4 - 1)
-        result = try MsgpackType.array(data).marshall()
+        data = [MsgpackElement](repeating: .bool(true), count: 1 << 4 - 1)
+        result = try MsgpackElement.array(data).marshall()
         XCTAssertEqual(
             result, [0x9f] + Data(repeating: 0xc3, count: 1 << 4 - 1))
 
-        data = [MsgpackType](repeating: .bool(true), count: 1 << 4)
-        result = try MsgpackType.array(data).marshall()
+        data = [MsgpackElement](repeating: .bool(true), count: 1 << 4)
+        result = try MsgpackElement.array(data).marshall()
         XCTAssertEqual(
             result, [0xdc, 0x00, 0x10] + Data(repeating: 0xc3, count: 1 << 4))
 
-        data = [MsgpackType](repeating: .bool(true), count: 1 << 16 - 1)
-        result = try MsgpackType.array(data).marshall()
+        data = [MsgpackElement](repeating: .bool(true), count: 1 << 16 - 1)
+        result = try MsgpackElement.array(data).marshall()
         XCTAssertEqual(
             result,
             [0xdc, 0xff, 0xff] + Data(repeating: 0xc3, count: 1 << 16 - 1))
 
-        data = [MsgpackType](repeating: .bool(true), count: 1 << 16)
-        result = try MsgpackType.array(data).marshall()
+        data = [MsgpackElement](repeating: .bool(true), count: 1 << 16)
+        result = try MsgpackElement.array(data).marshall()
         XCTAssertEqual(
             result,
             [0xdd, 0x00, 0x01, 0x00, 0x00]
@@ -204,8 +204,8 @@ class MsgpackEncoderTests: XCTestCase {
         data[Int(UInt32.max)] = Data([0xc9, 0xff, 0xff, 0xff, 0xff, 0xff])
         for (len, extPrefix) in data {
             let extData = Data(repeating: 1, count: len)
-            let msgpackType = MsgpackType.ext(-1, extData)
-            let result = try msgpackType.marshall()
+            let msgpackElement = MsgpackElement.ext(-1, extData)
+            let result = try msgpackElement.marshall()
             let expected = extPrefix + extData
             XCTAssertEqual(result, expected)
         }
@@ -221,53 +221,53 @@ class MsgpackEncoderTests: XCTestCase {
         }
     }
 
-    // MARK: Convert from basic Swift type to MsgpackType
+    // MARK: Convert from basic Swift type to MsgpackElement
     func testInitInt() throws {
-        XCTAssertEqual(MsgpackType(Int8(-1)), MsgpackType.int(Int64(-1)))
-        XCTAssertEqual(MsgpackType(Int16(-1)), MsgpackType.int(Int64(-1)))
-        XCTAssertEqual(MsgpackType(Int32(-1)), MsgpackType.int(Int64(-1)))
-        XCTAssertEqual(MsgpackType(Int64(-1)), MsgpackType.int(Int64(-1)))
+        XCTAssertEqual(MsgpackElement(Int8(-1)), MsgpackElement.int(Int64(-1)))
+        XCTAssertEqual(MsgpackElement(Int16(-1)), MsgpackElement.int(Int64(-1)))
+        XCTAssertEqual(MsgpackElement(Int32(-1)), MsgpackElement.int(Int64(-1)))
+        XCTAssertEqual(MsgpackElement(Int64(-1)), MsgpackElement.int(Int64(-1)))
     }
 
     func testInitUInt() throws {
-        XCTAssertEqual(MsgpackType(UInt8(1)), MsgpackType.uint(UInt64(1)))
-        XCTAssertEqual(MsgpackType(UInt16(1)), MsgpackType.uint(UInt64(1)))
-        XCTAssertEqual(MsgpackType(UInt32(1)), MsgpackType.uint(UInt64(1)))
-        XCTAssertEqual(MsgpackType(UInt64(1)), MsgpackType.uint(UInt64(1)))
+        XCTAssertEqual(MsgpackElement(UInt8(1)), MsgpackElement.uint(UInt64(1)))
+        XCTAssertEqual(MsgpackElement(UInt16(1)), MsgpackElement.uint(UInt64(1)))
+        XCTAssertEqual(MsgpackElement(UInt32(1)), MsgpackElement.uint(UInt64(1)))
+        XCTAssertEqual(MsgpackElement(UInt64(1)), MsgpackElement.uint(UInt64(1)))
     }
 
     // The compiler implement its encodable as Float32
     func testFloat16() throws {
         let encoder = MsgpackEncoder()
         _ = try encoder.encode(Float16(1))
-        let msgpackType = try encoder.msgpack?.convertToMsgpackType()
-        XCTAssertEqual(msgpackType, MsgpackType.float32(Float32(1)))
+        let msgpackElement = try encoder.msgpack?.convertToMsgpackElement()
+        XCTAssertEqual(msgpackElement, MsgpackElement.float32(Float32(1)))
     }
 
     func testInitFloat32() throws {
-        XCTAssertEqual(MsgpackType(Float32(1)), MsgpackType.float32(Float32(1)))
+        XCTAssertEqual(MsgpackElement(Float32(1)), MsgpackElement.float32(Float32(1)))
     }
 
     func testInitFloat64() throws {
-        XCTAssertEqual(MsgpackType(Float64(1)), MsgpackType.float64(Float64(1)))
+        XCTAssertEqual(MsgpackElement(Float64(1)), MsgpackElement.float64(Float64(1)))
     }
 
     func testInitBool() throws {
-        XCTAssertEqual(MsgpackType(true), MsgpackType.bool(true))
-        XCTAssertEqual(MsgpackType(false), MsgpackType.bool(false))
+        XCTAssertEqual(MsgpackElement(true), MsgpackElement.bool(true))
+        XCTAssertEqual(MsgpackElement(false), MsgpackElement.bool(false))
     }
 
     func testInitString() throws {
-        XCTAssertEqual(MsgpackType("abc"), MsgpackType.string("abc"))
+        XCTAssertEqual(MsgpackElement("abc"), MsgpackElement.string("abc"))
     }
 
     func testInitData() throws {
-        XCTAssertEqual(MsgpackType(Data([123])), MsgpackType.bin(Data([123])))
+        XCTAssertEqual(MsgpackElement(Data([123])), MsgpackElement.bin(Data([123])))
     }
 
     func testMapArrayNotInited() throws {
-        XCTAssertEqual(MsgpackType([String: String]()), nil)
-        XCTAssertEqual(MsgpackType([String]()), nil)
+        XCTAssertEqual(MsgpackElement([String: String]()), nil)
+        XCTAssertEqual(MsgpackElement([String]()), nil)
     }
 
     // MARK: MsgpackEncoder encode
@@ -308,35 +308,35 @@ class MsgpackEncoderTests: XCTestCase {
         let encoder = MsgpackEncoder()
         let example = DefaultEncodeExample()
         _ = try encoder.encode(example)
-        let msgpackType = try encoder.convertToMsgpackType()
-        guard case let MsgpackType.map(m) = msgpackType else {
-            XCTFail("Decoded to unexpected msgpack type:\(msgpackType)")
+        let msgpackElement = try encoder.convertToMsgpackElement()
+        guard case let MsgpackElement.map(m) = msgpackElement else {
+            XCTFail("Decoded to unexpected msgpack type:\(msgpackElement)")
             return
         }
         XCTAssertEqual(m.count, 13)
-        XCTAssertEqual(m["int"], MsgpackType.int(Int64(2)))
+        XCTAssertEqual(m["int"], MsgpackElement.int(Int64(2)))
         XCTAssertEqual(m["intNil"], nil)
-        XCTAssertEqual(m["bool"], MsgpackType.bool(true))
-        XCTAssertEqual(m["boolNil"], MsgpackType.bool(true))
-        XCTAssertEqual(m["string"], MsgpackType.string("123"))
-        XCTAssertEqual(m["data"], MsgpackType.bin(Data([0x90])))
-        XCTAssertEqual(m["float32"], MsgpackType.float32(Float32(1.1)))
-        XCTAssertEqual(m["float64"], MsgpackType.float64(Float64(1.1)))
-        XCTAssertEqual(m["map1"], MsgpackType.map([String: MsgpackType]()))
-        var map2: [String: MsgpackType] = [:]
-        map2["a"] = MsgpackType.bool(true)
-        XCTAssertEqual(m["map2"], MsgpackType.map(map2))
-        var map3: [String: MsgpackType] = [:]
-        map3["b"] = MsgpackType.map(map2)
-        XCTAssertEqual(m["map3"], MsgpackType.map(map3))
+        XCTAssertEqual(m["bool"], MsgpackElement.bool(true))
+        XCTAssertEqual(m["boolNil"], MsgpackElement.bool(true))
+        XCTAssertEqual(m["string"], MsgpackElement.string("123"))
+        XCTAssertEqual(m["data"], MsgpackElement.bin(Data([0x90])))
+        XCTAssertEqual(m["float32"], MsgpackElement.float32(Float32(1.1)))
+        XCTAssertEqual(m["float64"], MsgpackElement.float64(Float64(1.1)))
+        XCTAssertEqual(m["map1"], MsgpackElement.map([String: MsgpackElement]()))
+        var map2: [String: MsgpackElement] = [:]
+        map2["a"] = MsgpackElement.bool(true)
+        XCTAssertEqual(m["map2"], MsgpackElement.map(map2))
+        var map3: [String: MsgpackElement] = [:]
+        map3["b"] = MsgpackElement.map(map2)
+        XCTAssertEqual(m["map3"], MsgpackElement.map(map3))
         let array1 = [
-            MsgpackType.int(1), MsgpackType.int(2), MsgpackType.null,
-            MsgpackType.int(4),
+            MsgpackElement.int(1), MsgpackElement.int(2), MsgpackElement.null,
+            MsgpackElement.int(4),
         ]
-        XCTAssertEqual(m["array1"], MsgpackType.array(array1))
-        var array2: [MsgpackType] = []
-        array2.append(MsgpackType.array(array1))
-        XCTAssertEqual(m["array2"], MsgpackType.array(array2))
+        XCTAssertEqual(m["array1"], MsgpackElement.array(array1))
+        var array2: [MsgpackElement] = []
+        array2.append(MsgpackElement.array(array1))
+        XCTAssertEqual(m["array2"], MsgpackElement.array(array2))
     }
 
     private class ManualEncodeExample: Encodable {
@@ -364,18 +364,18 @@ class MsgpackEncoderTests: XCTestCase {
         let example2 = ManualEncodeExample()
         let encoder = MsgpackEncoder()
         _ = try encoder.encode(example2)
-        let msgpackType = try encoder.convertToMsgpackType()
+        let msgpackElement = try encoder.convertToMsgpackElement()
 
-        var map: [String: MsgpackType] = [:]
-        map["Key1"] = MsgpackType.int(123)
-        var nestedMap: [String: MsgpackType] = [:]
-        nestedMap["nestedKey1"] = MsgpackType.string("123")
-        map["Key2"] = MsgpackType.map(nestedMap)
-        var nestedArray: [MsgpackType] = []
-        nestedArray.append(MsgpackType.bin(Data([0x12])))
-        map["Key3"] = MsgpackType.array(nestedArray)
-        let expected = MsgpackType.map(map)
-        XCTAssertEqual(msgpackType, expected)
+        var map: [String: MsgpackElement] = [:]
+        map["Key1"] = MsgpackElement.int(123)
+        var nestedMap: [String: MsgpackElement] = [:]
+        nestedMap["nestedKey1"] = MsgpackElement.string("123")
+        map["Key2"] = MsgpackElement.map(nestedMap)
+        var nestedArray: [MsgpackElement] = []
+        nestedArray.append(MsgpackElement.bin(Data([0x12])))
+        map["Key3"] = MsgpackElement.array(nestedArray)
+        let expected = MsgpackElement.map(map)
+        XCTAssertEqual(msgpackElement, expected)
     }
 
     private class BaseClassExample: Encodable {
@@ -401,15 +401,15 @@ class MsgpackEncoderTests: XCTestCase {
         let encoder = MsgpackEncoder()
         let example = InherienceWithSameContainerExample()
         _ = try encoder.encode(example)
-        let msgpackType = try encoder.convertToMsgpackType()
-        guard case let MsgpackType.map(m) = msgpackType else {
-            XCTFail("The msgpackType should be map")
+        let msgpackElement = try encoder.convertToMsgpackElement()
+        guard case let MsgpackElement.map(m) = msgpackElement else {
+            XCTFail("The msgpackElement should be map")
             return
         }
         XCTAssertEqual(m.count, 2)
-        XCTAssertEqual(m["parent"], MsgpackType.bool(true))
-        XCTAssertEqual(m["child"], MsgpackType.bool(true))
-        print(msgpackType)
+        XCTAssertEqual(m["parent"], MsgpackElement.bool(true))
+        XCTAssertEqual(m["child"], MsgpackElement.bool(true))
+        print(msgpackElement)
     }
 
     private class KeyedSuperExample: BaseClassExample {
@@ -432,19 +432,19 @@ class MsgpackEncoderTests: XCTestCase {
         let encoder = MsgpackEncoder()
         let example = KeyedSuperExample()
         _ = try encoder.encode(example)
-        let msgpackType = try encoder.convertToMsgpackType()
-        guard case let MsgpackType.map(m) = msgpackType else {
-            XCTFail("The msgpackType should be map")
+        let msgpackElement = try encoder.convertToMsgpackElement()
+        guard case let MsgpackElement.map(m) = msgpackElement else {
+            XCTFail("The msgpackElement should be map")
             return
         }
 
         XCTAssertEqual(m.count, 3)
-        var parent: [String: MsgpackType] = [:]
-        parent["parent"] = MsgpackType.bool(true)
-        let parentMsgpackType = MsgpackType.map(parent)
-        XCTAssertEqual(m["super"], parentMsgpackType)
-        XCTAssertEqual(m["super2"], parentMsgpackType)
-        XCTAssertEqual(m["child"], MsgpackType.bool(true))
+        var parent: [String: MsgpackElement] = [:]
+        parent["parent"] = MsgpackElement.bool(true)
+        let parentMsgpackElement = MsgpackElement.map(parent)
+        XCTAssertEqual(m["super"], parentMsgpackElement)
+        XCTAssertEqual(m["super2"], parentMsgpackElement)
+        XCTAssertEqual(m["child"], MsgpackElement.bool(true))
     }
 
     private class UnkeyedSuperExample: BaseClassExample {
@@ -460,19 +460,19 @@ class MsgpackEncoderTests: XCTestCase {
         let encoder = MsgpackEncoder()
         let example = UnkeyedSuperExample()
         _ = try encoder.encode(example)
-        let msgpackType = try encoder.convertToMsgpackType()
-        guard case let MsgpackType.array(array) = msgpackType else {
-            XCTFail("The msgpackType should be array")
+        let msgpackElement = try encoder.convertToMsgpackElement()
+        guard case let MsgpackElement.array(array) = msgpackElement else {
+            XCTFail("The msgpackElement should be array")
             return
         }
 
         _ = try JSONEncoder().encode(example)
         XCTAssertEqual(array.count, 2)
-        var parent: [String: MsgpackType] = [:]
-        parent["parent"] = MsgpackType.bool(true)
-        let parentMsgpackType = MsgpackType.map(parent)
-        XCTAssertEqual(array[0], MsgpackType.bool(true))
-        XCTAssertEqual(array[1], parentMsgpackType)
+        var parent: [String: MsgpackElement] = [:]
+        parent["parent"] = MsgpackElement.bool(true)
+        let parentMsgpackElement = MsgpackElement.map(parent)
+        XCTAssertEqual(array[0], MsgpackElement.bool(true))
+        XCTAssertEqual(array[1], parentMsgpackElement)
     }
 
     // MARK: Extension
@@ -508,8 +508,8 @@ class MsgpackEncoderTests: XCTestCase {
                 seconds: seconds, nanoseconds: nanoseconds)
             let encoder = MsgpackEncoder()
             _ = try encoder.encode(timestamp)
-            let msgpackType = try encoder.convertToMsgpackType()
-            guard case let MsgpackType.ext(extType, extData) = msgpackType
+            let msgpackElement = try encoder.convertToMsgpackElement()
+            guard case let MsgpackElement.ext(extType, extData) = msgpackElement
             else {
                 XCTFail("Encoder should produce extension type")
                 return

--- a/Tests/SignalRClientTests/Msgpack/MsgpackEncoderTests.swift
+++ b/Tests/SignalRClientTests/Msgpack/MsgpackEncoderTests.swift
@@ -1,0 +1,648 @@
+import Foundation
+import MessagePacker
+import XCTest
+
+@testable import SignalRClient
+
+class MsgpackEncoderTests: XCTestCase {
+    // MARK: Convert MsgpackType to Data
+    func testEncodeUInt() throws {
+        var data: [UInt64: Data] = [:]
+        data[0x00] = Data([0x00])
+        data[0x7f] = Data([0x7f])
+        data[0x80] = Data([0xcc, 0x80])
+        data[0xff] = Data([0xcc, 0xff])
+        data[0x100] = Data([0xcd, 0x01, 0x00])
+        data[0xffff] = Data([0xcd, 0xff, 0xff])
+        data[0x10000] = Data([0xce, 0x00, 0x01, 0x00, 0x00])
+        data[0xffff_ffff] = Data([0xce, 0xff, 0xff, 0xff, 0xff])
+        data[0x1_0000_0000] = Data([
+            0xcf, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        ])
+        for (uint64, expected) in data {
+            let result = try MsgpackType.uint(uint64).marshall()
+            XCTAssertEqual(result, expected)
+        }
+    }
+
+    func testEncodeInt() throws {
+        var data: [Int64: Data] = [:]
+        data[-0x20] = Data([0xe0])
+        data[-0x21] = Data([0xd0, 0xdf])
+        data[-0x80] = Data([0xd0, 0x80])
+        data[-0x81] = Data([0xd1, 0xff, 0x7f])
+        data[-0x8000] = Data([0xd1, 0x80, 0x00])
+        data[-0x8001] = Data([0xd2, 0xff, 0xff, 0x7f, 0xff])
+        data[-0x8000_0000] = Data([0xd2, 0x80, 0x00, 0x00, 0x00])
+        data[-0x8000_0001] = Data([
+            0xd3, 0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff,
+        ])
+        data[0x00] = Data([0x00])
+        data[0x7f] = Data([0x7f])
+        for (int64, expected) in data {
+            let result = try MsgpackType.int(int64).marshall()
+            XCTAssertEqual(result, expected)
+        }
+    }
+
+    func testEncodeFloat32() throws {
+        var data: [Float32: Data] = [:]
+        data[0.0] = Data([0xca, 0x00, 0x00, 0x00, 0x00])
+        data[1.1] = Data([0xca, 0x3f, 0x8c, 0xcc, 0xcd])
+        data[-0.9] = Data([0xca, 0xbf, 0x66, 0x66, 0x66])
+        for (float32, expected) in data {
+            let result = try MsgpackType.float32(float32).marshall()
+            XCTAssertEqual(result, expected)
+        }
+    }
+
+    func testEncodeFloat64() throws {
+        var data: [Float64: Data] = [:]
+        data[0.0] = Data([0xcb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        data[1.1] = Data([0xcb, 0x3f, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a])
+        data[-0.9] = Data([
+            0xcb, 0xbf, 0xec, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcd,
+        ])
+        for (float64, expected) in data {
+            let result = try MsgpackType.float64(float64).marshall()
+            XCTAssertEqual(result, expected)
+        }
+    }
+
+    func testEncodeString() throws {
+        var data: [Int: Data] = [:]
+        data[0] = Data([0xa0])
+        data[1 << 5 - 1] = [0xbf] + Data(repeating: 0x61, count: 1 << 5 - 1)
+        data[1 << 5] = [0xd9, 0x20] + Data(repeating: 0x61, count: 1 << 5)
+        data[1 << 8 - 1] =
+            [0xd9, 0xff] + Data(repeating: 0x61, count: 1 << 8 - 1)
+        data[1 << 8] =
+            [0xda, 0x01, 0x00] + Data(repeating: 0x61, count: 1 << 8)
+        data[1 << 16 - 1] =
+            [0xda, 0xff, 0xff] + Data(repeating: 0x61, count: 1 << 16 - 1)
+        data[1 << 16] =
+            [0xdb, 0x00, 0x01, 0x00, 0x00]
+            + Data(repeating: 0x61, count: 1 << 16)
+        for (length, expected) in data {
+            let string = String(repeating: Character("a"), count: length)
+            let result = try MsgpackType.string(string).marshall()
+            XCTAssertEqual(result, expected)
+        }
+    }
+
+    func testEncodeBool() throws {
+        var data: [Bool: Data] = [:]
+        data[true] = Data([0xc3])
+        data[false] = Data([0xc2])
+        for (bool, expected) in data {
+            let result = try MsgpackType.bool(bool).marshall()
+            XCTAssertEqual(result, expected)
+        }
+    }
+
+    func testEncodeNil() throws {
+        let expected = Data([0xc0])
+        let result = try MsgpackType.null.marshall()
+        XCTAssertEqual(result, expected)
+    }
+
+    func testEncodeData() throws {
+        var data: [Int: Data] = [:]
+        data[0] = Data([0xc4, 0x00])
+        data[1 << 8 - 1] =
+            [0xc4, 0xff] + Data(repeating: UInt8(1), count: 1 << 8 - 1)
+        data[1 << 8] =
+            [0xc5, 0x01, 0x00] + Data(repeating: UInt8(1), count: 1 << 8)
+        data[1 << 16 - 1] =
+            [0xc5, 0xff, 0xff] + Data(repeating: UInt8(1), count: 1 << 16 - 1)
+        data[1 << 16] =
+            [0xc6, 0x00, 0x01, 0x00, 0x00]
+            + Data(repeating: UInt8(1), count: 1 << 16)
+        for (length, expected) in data {
+            let data = Data(repeating: UInt8(1), count: length)
+            let result = try MsgpackType.bin(data).marshall()
+            XCTAssertEqual(result, expected)
+        }
+    }
+
+    func testEncodeMap() throws {
+        var map: [String: MsgpackType] = [:]
+        var result = try MsgpackType.map(map).marshall()
+        XCTAssertEqual(result, Data([0x80]))
+        for i in 0..<1 << 4 - 1 {
+            map[String(i)] = MsgpackType.bool(true)
+        }
+        result = try MsgpackType.map(map).marshall()
+        XCTAssertEqual(result.count, 51)
+        XCTAssertEqual(result[0], 0x8f)
+
+        map.removeAll()
+        for i in 0..<1 << 4 {
+            map[String(i)] = MsgpackType.bool(true)
+        }
+        result = try MsgpackType.map(map).marshall()
+        XCTAssertEqual(result.count, 57)
+        XCTAssertEqual(result[0...2], Data([0xde, 0x00, 0x10]))
+
+        map.removeAll()
+        for i in 0..<1 << 16 - 1 {
+            map[String(i)] = MsgpackType.bool(true)
+        }
+        result = try MsgpackType.map(map).marshall()
+        XCTAssertEqual(result.count, 447638)
+        XCTAssertEqual(result[0...2], Data([0xde, 0xff, 0xff]))
+
+        map.removeAll()
+        for i in 0..<1 << 16 {
+            map[String(i)] = MsgpackType.bool(true)
+        }
+        result = try MsgpackType.map(map).marshall()
+        XCTAssertEqual(result.count, 447647)
+        XCTAssertEqual(result[0...4], Data([0xdf, 0x00, 0x01, 0x00, 0x00]))
+    }
+
+    func testEncodeArray() throws {
+        var data: [MsgpackType] = []
+        var result = try MsgpackType.array(data).marshall()
+        XCTAssertEqual(result, Data([0x90]))
+
+        data = [MsgpackType](repeating: .bool(true), count: 1 << 4 - 1)
+        result = try MsgpackType.array(data).marshall()
+        XCTAssertEqual(
+            result, [0x9f] + Data(repeating: 0xc3, count: 1 << 4 - 1))
+
+        data = [MsgpackType](repeating: .bool(true), count: 1 << 4)
+        result = try MsgpackType.array(data).marshall()
+        XCTAssertEqual(
+            result, [0xdc, 0x00, 0x10] + Data(repeating: 0xc3, count: 1 << 4))
+
+        data = [MsgpackType](repeating: .bool(true), count: 1 << 16 - 1)
+        result = try MsgpackType.array(data).marshall()
+        XCTAssertEqual(
+            result,
+            [0xdc, 0xff, 0xff] + Data(repeating: 0xc3, count: 1 << 16 - 1))
+
+        data = [MsgpackType](repeating: .bool(true), count: 1 << 16)
+        result = try MsgpackType.array(data).marshall()
+        XCTAssertEqual(
+            result,
+            [0xdd, 0x00, 0x01, 0x00, 0x00]
+                + Data(repeating: 0xc3, count: 1 << 16))
+    }
+
+    func testEncodeExtension() throws {
+        var data: [Int: Data] = [:]
+        data[1] = Data([0xd4, 0xff])
+        data[2] = Data([0xd5, 0xff])
+        data[4] = Data([0xd6, 0xff])
+        data[8] = Data([0xd7, 0xff])
+        data[16] = Data([0xd8, 0xff])
+        data[0] = Data([0xc7, 0x00, 0xff])
+        data[1 << 8 - 1] = Data([0xc7, 0xff, 0xff])
+        data[1 << 8] = Data([0xc8, 0x01, 0x00, 0xff])
+        data[1 << 16 - 1] = Data([0xc8, 0xff, 0xff, 0xff])
+        data[1 << 16] = Data([0xc9, 0x00, 0x01, 0x00, 0x00, 0xff])
+        data[Int(UInt32.max)] = Data([0xc9, 0xff, 0xff, 0xff, 0xff, 0xff])
+        for (len, extPrefix) in data {
+            let extData = Data(repeating: 1, count: len)
+            let msgpackType = MsgpackType.ext(-1, extData)
+            let result = try msgpackType.marshall()
+            let expected = extPrefix + extData
+            XCTAssertEqual(result, expected)
+        }
+    }
+
+    // Used for debugging
+    func testAgainstExpected(v: Encodable, expected: Data, result: Data) throws
+    {
+        if expected != result {
+            print(expected.hexEncodedString())
+            print(result.hexEncodedString())
+            XCTFail("encoded result for \(v) not equal to expected")
+        }
+    }
+
+    // MARK: Convert from basic Swift type to MsgpackType
+    func testInitInt() throws {
+        XCTAssertEqual(MsgpackType(Int8(-1)), MsgpackType.int(Int64(-1)))
+        XCTAssertEqual(MsgpackType(Int16(-1)), MsgpackType.int(Int64(-1)))
+        XCTAssertEqual(MsgpackType(Int32(-1)), MsgpackType.int(Int64(-1)))
+        XCTAssertEqual(MsgpackType(Int64(-1)), MsgpackType.int(Int64(-1)))
+    }
+
+    func testInitUInt() throws {
+        XCTAssertEqual(MsgpackType(UInt8(1)), MsgpackType.uint(UInt64(1)))
+        XCTAssertEqual(MsgpackType(UInt16(1)), MsgpackType.uint(UInt64(1)))
+        XCTAssertEqual(MsgpackType(UInt32(1)), MsgpackType.uint(UInt64(1)))
+        XCTAssertEqual(MsgpackType(UInt64(1)), MsgpackType.uint(UInt64(1)))
+    }
+
+    // The compiler implement its encodable as Float32
+    func testFloat16() throws {
+        let encoder = MsgpackEncoder()
+        _ = try encoder.encode(Float16(1))
+        let msgpackType = try encoder.msgpack?.convertToMsgpackType()
+        XCTAssertEqual(msgpackType, MsgpackType.float32(Float32(1)))
+    }
+
+    func testInitFloat32() throws {
+        XCTAssertEqual(MsgpackType(Float32(1)), MsgpackType.float32(Float32(1)))
+    }
+
+    func testInitFloat64() throws {
+        XCTAssertEqual(MsgpackType(Float64(1)), MsgpackType.float64(Float64(1)))
+    }
+
+    func testInitBool() throws {
+        XCTAssertEqual(MsgpackType(true), MsgpackType.bool(true))
+        XCTAssertEqual(MsgpackType(false), MsgpackType.bool(false))
+    }
+
+    func testInitString() throws {
+        XCTAssertEqual(MsgpackType("abc"), MsgpackType.string("abc"))
+    }
+
+    func testInitData() throws {
+        XCTAssertEqual(MsgpackType(Data([123])), MsgpackType.bin(Data([123])))
+    }
+
+    func testMapArrayNotInited() throws {
+        XCTAssertEqual(MsgpackType([String: String]()), nil)
+        XCTAssertEqual(MsgpackType([String]()), nil)
+    }
+
+    // MARK: MsgpackEncoder encode
+    private class DefaultEncodeExample: Encodable {
+        var int: Int
+        var intNil: Int?
+        var bool: Bool
+        var boolNil: Bool?
+        var string: String
+        var data: Data
+        var float32: Float32
+        var float64: Float64
+        var map1: [String: String]
+        var map2: [String: Bool]
+        var map3: [String: [String: Bool]]
+        var array1: [Int?]
+        var array2: [[Int?]]
+        var date: Date
+
+        init() {
+            self.int = 2
+            self.boolNil = true
+            self.bool = true
+            self.string = "123"
+            self.data = Data([0x90])
+            self.float32 = 1.1
+            self.float64 = 1.1
+            self.map1 = [:]
+            self.map2 = ["a": true]
+            self.map3 = ["b": map2]
+            self.array1 = [1, 2, nil, 4]
+            self.array2 = [self.array1]
+            self.date = Date(timeIntervalSince1970: 100.1)
+        }
+    }
+
+    func testDefaultEncode() throws {
+        let encoder = MsgpackEncoder()
+        let example = DefaultEncodeExample()
+        _ = try encoder.encode(example)
+        let msgpackType = try encoder.convertToMsgpackType()
+        guard case let MsgpackType.map(m) = msgpackType else {
+            XCTFail("Decoded to unexpected msgpack type:\(msgpackType)")
+            return
+        }
+        XCTAssertEqual(m.count, 13)
+        XCTAssertEqual(m["int"], MsgpackType.int(Int64(2)))
+        XCTAssertEqual(m["intNil"], nil)
+        XCTAssertEqual(m["bool"], MsgpackType.bool(true))
+        XCTAssertEqual(m["boolNil"], MsgpackType.bool(true))
+        XCTAssertEqual(m["string"], MsgpackType.string("123"))
+        XCTAssertEqual(m["data"], MsgpackType.bin(Data([0x90])))
+        XCTAssertEqual(m["float32"], MsgpackType.float32(Float32(1.1)))
+        XCTAssertEqual(m["float64"], MsgpackType.float64(Float64(1.1)))
+        XCTAssertEqual(m["map1"], MsgpackType.map([String: MsgpackType]()))
+        var map2: [String: MsgpackType] = [:]
+        map2["a"] = MsgpackType.bool(true)
+        XCTAssertEqual(m["map2"], MsgpackType.map(map2))
+        var map3: [String: MsgpackType] = [:]
+        map3["b"] = MsgpackType.map(map2)
+        XCTAssertEqual(m["map3"], MsgpackType.map(map3))
+        let array1 = [
+            MsgpackType.int(1), MsgpackType.int(2), MsgpackType.null,
+            MsgpackType.int(4),
+        ]
+        XCTAssertEqual(m["array1"], MsgpackType.array(array1))
+        var array2: [MsgpackType] = []
+        array2.append(MsgpackType.array(array1))
+        XCTAssertEqual(m["array2"], MsgpackType.array(array2))
+    }
+
+    private class ManualEncodeExample: Encodable {
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: Keys.self)
+            try container.encode(123, forKey: .Key1)
+            var nestedKeyedContainer1 = container.nestedContainer(
+                keyedBy: Keys.self, forKey: Keys.Key2)
+            try nestedKeyedContainer1.encode("123", forKey: Keys.nestedKey1)
+            var nestedUnkeyedContainer = container.nestedUnkeyedContainer(
+                forKey: Keys.Key3)
+            try nestedUnkeyedContainer.encode(Data([0x12]))
+        }
+
+        enum Keys: CodingKey {
+            case Key1
+            case Key2
+            case Key3
+
+            case nestedKey1
+        }
+    }
+
+    func testManualEncode() throws {
+        let example2 = ManualEncodeExample()
+        let encoder = MsgpackEncoder()
+        _ = try encoder.encode(example2)
+        let msgpackType = try encoder.convertToMsgpackType()
+
+        var map: [String: MsgpackType] = [:]
+        map["Key1"] = MsgpackType.int(123)
+        var nestedMap: [String: MsgpackType] = [:]
+        nestedMap["nestedKey1"] = MsgpackType.string("123")
+        map["Key2"] = MsgpackType.map(nestedMap)
+        var nestedArray: [MsgpackType] = []
+        nestedArray.append(MsgpackType.bin(Data([0x12])))
+        map["Key3"] = MsgpackType.array(nestedArray)
+        let expected = MsgpackType.map(map)
+        XCTAssertEqual(msgpackType, expected)
+    }
+
+    private class BaseClassExample: Encodable {
+        var parent: Bool = true
+    }
+
+    private class InherienceWithSameContainerExample: BaseClassExample {
+        var child: Bool = true
+
+        override func encode(to encoder: any Encoder) throws {
+            try super.encode(to: encoder)
+            // Switching to a KeyedContainer with different key type
+            var container = encoder.container(keyedBy: Keys.self)
+            try container.encode(child, forKey: .child)
+        }
+
+        enum Keys: CodingKey {
+            case child
+        }
+    }
+
+    func testInherienceUsingSameTopContainer() throws {  // Undocumented behavior. Keep aligh with the jsonEncoder
+        let encoder = MsgpackEncoder()
+        let example = InherienceWithSameContainerExample()
+        _ = try encoder.encode(example)
+        let msgpackType = try encoder.convertToMsgpackType()
+        guard case let MsgpackType.map(m) = msgpackType else {
+            XCTFail("The msgpackType should be map")
+            return
+        }
+        XCTAssertEqual(m.count, 2)
+        XCTAssertEqual(m["parent"], MsgpackType.bool(true))
+        XCTAssertEqual(m["child"], MsgpackType.bool(true))
+        print(msgpackType)
+    }
+
+    private class KeyedSuperExample: BaseClassExample {
+        var child: Bool = true
+        override func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: Keys.self)
+            try container.encode(child, forKey: .child)
+            let superencoder = container.superEncoder()
+            try super.encode(to: superencoder)
+            let superencoder2 = container.superEncoder(forKey: Keys.super2)
+            try super.encode(to: superencoder2)
+        }
+        enum Keys: CodingKey {
+            case child
+            case super2
+        }
+    }
+
+    func testKeyedInherience() throws {
+        let encoder = MsgpackEncoder()
+        let example = KeyedSuperExample()
+        _ = try encoder.encode(example)
+        let msgpackType = try encoder.convertToMsgpackType()
+        guard case let MsgpackType.map(m) = msgpackType else {
+            XCTFail("The msgpackType should be map")
+            return
+        }
+
+        XCTAssertEqual(m.count, 3)
+        var parent: [String: MsgpackType] = [:]
+        parent["parent"] = MsgpackType.bool(true)
+        let parentMsgpackType = MsgpackType.map(parent)
+        XCTAssertEqual(m["super"], parentMsgpackType)
+        XCTAssertEqual(m["super2"], parentMsgpackType)
+        XCTAssertEqual(m["child"], MsgpackType.bool(true))
+    }
+
+    private class UnkeyedSuperExample: BaseClassExample {
+        override func encode(to encoder: any Encoder) throws {
+            var container = encoder.unkeyedContainer()
+            try container.encode(true)
+            let encoder = container.superEncoder()
+            try super.encode(to: encoder)
+        }
+    }
+
+    func testUnkeyedInherience() throws {
+        let encoder = MsgpackEncoder()
+        let example = UnkeyedSuperExample()
+        _ = try encoder.encode(example)
+        let msgpackType = try encoder.convertToMsgpackType()
+        guard case let MsgpackType.array(array) = msgpackType else {
+            XCTFail("The msgpackType should be array")
+            return
+        }
+
+        _ = try JSONEncoder().encode(example)
+        XCTAssertEqual(array.count, 2)
+        var parent: [String: MsgpackType] = [:]
+        parent["parent"] = MsgpackType.bool(true)
+        let parentMsgpackType = MsgpackType.map(parent)
+        XCTAssertEqual(array[0], MsgpackType.bool(true))
+        XCTAssertEqual(array[1], parentMsgpackType)
+    }
+
+    // MARK: Extension
+    func testEncodeTimestamp() throws {
+        var data: [Double: Data] = [:]
+        data[0] = Data([0x0, 0x0, 0x0, 0x0])
+        data[-0.5] = Data([
+            0x1d, 0xcd, 0x65, 0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff,
+        ])
+        data[-1.5] = Data([
+            0x1d, 0xcd, 0x65, 0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xfe,
+        ])
+        data[1.5] = Data([0x77, 0x35, 0x94, 0x0, 0x0, 0x0, 0x0, 0x1])
+        data[Double(UInt32.max)] = Data([0xff, 0xff, 0xff, 0xff])
+        data[Double(UInt32.max) + 1] = Data([
+            0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0,
+        ])
+        data[Double(UInt64(1) << 34 - 1)] = Data([
+            0x0, 0x0, 0x0, 0x3, 0xff, 0xff, 0xff, 0xff,
+        ])
+        data[Double(UInt64(1) << 34)] = Data([
+            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4, 0x0, 0x0, 0x0, 0x0,
+        ])
+
+        for (time, expected) in data {
+            let seconds = Int64(time.rounded(FloatingPointRoundingRule.down))
+            let nanoseconds = UInt32(
+                ((time - Double(seconds)) * 1_000_000_000).rounded(
+                    FloatingPointRoundingRule.down))
+            let timestamp = MsgpackTimestamp(
+                seconds: seconds, nanoseconds: nanoseconds)
+            let encoder = MsgpackEncoder()
+            _ = try encoder.encode(timestamp)
+            let msgpackType = try encoder.convertToMsgpackType()
+            guard case let MsgpackType.ext(extType, extData) = msgpackType
+            else {
+                XCTFail("Encoder should produce extension type")
+                return
+            }
+            XCTAssertEqual(extType, -1)
+            XCTAssertEqual(extData, expected)
+        }
+    }
+
+    // MARK: User Info
+    struct UserInfoExample: Encodable {
+        func encode(to encoder: any Encoder) throws {
+            let userInfo = encoder.userInfo
+            AsserUserInfo(userInfo)
+            var container1 = encoder.container(keyedBy: Keys.self)
+            let superEncoder = container1.superEncoder()
+            AsserUserInfo(superEncoder.userInfo)
+            _ = superEncoder.singleValueContainer()
+            let superEncoder2 = container1.superEncoder(forKey: .Key1)
+            AsserUserInfo(superEncoder2.userInfo)
+            var container3 = superEncoder2.unkeyedContainer()
+            let superEncoder3 = container3.superEncoder()
+            _ = superEncoder3.singleValueContainer()
+            AsserUserInfo(superEncoder3.userInfo)
+        }
+
+        enum Keys: CodingKey {
+            case Key1
+        }
+
+        func AsserUserInfo(_ userInfo: [CodingUserInfoKey: Any]) {
+            XCTAssertEqual(userInfo.count, 1)
+            let key = CodingUserInfoKey(rawValue: "key")!
+            XCTAssertEqual(userInfo[key] as! String, "value")
+        }
+    }
+
+    func testUserInfo() throws {
+        var userInfo: [CodingUserInfoKey: Any] = [:]
+        let key = CodingUserInfoKey(rawValue: "key")!
+        userInfo[key] = "value"
+        let encoder = JSONEncoder()
+        encoder.userInfo[key] = "value"
+        let example = UserInfoExample()
+        _ = try encoder.encode(example)
+    }
+
+    // MARK: CodingKey
+    struct CodingKeyExample: Encodable {
+        func encode(to encoder: any Encoder) throws {
+            XCTAssertEqual(encoder.codingPath.count, 0)
+            var container1 = encoder.container(keyedBy: Keys.self)
+            XCTAssertEqual(container1.codingPath.count, 0)
+
+            let superEncoder = container1.superEncoder()
+            XCTAssertEqual(superEncoder.codingPath.count, 1)
+            XCTAssertEqual(
+                superEncoder.codingPath[0] as! MsgpackCodingKey,
+                MsgpackCodingKey(stringValue: "super"))
+            let superSingleValueContainer = superEncoder.singleValueContainer()
+            XCTAssertEqual(superSingleValueContainer.codingPath.count, 1)
+            XCTAssertEqual(
+                superSingleValueContainer.codingPath[0] as! MsgpackCodingKey,
+                MsgpackCodingKey(stringValue: "super"))
+
+            let superEncoder2 = container1.superEncoder(forKey: .superKey)
+            XCTAssertEqual(superEncoder2.codingPath.count, 1)
+            XCTAssertEqual(superEncoder2.codingPath[0] as! Keys, Keys.superKey)
+            let superSingleValueContainer2 =
+                superEncoder2.singleValueContainer()
+            XCTAssertEqual(superSingleValueContainer2.codingPath.count, 1)
+            XCTAssertEqual(
+                superSingleValueContainer2.codingPath[0] as! Keys, Keys.superKey
+            )
+
+            XCTAssertEqual(container1.codingPath.count, 0)
+            var container2 = container1.nestedContainer(
+                keyedBy: Keys.self, forKey: .Key1)
+            XCTAssertEqual(container2.codingPath.count, 1)
+            XCTAssertEqual(container2.codingPath[0] as! Keys, Keys.Key1)
+
+            var container3 = container2.nestedUnkeyedContainer(forKey: .Key2)
+            XCTAssertEqual(container3.codingPath.count, 2)
+            XCTAssertEqual(container3.codingPath[0] as! Keys, Keys.Key1)
+            XCTAssertEqual(container3.codingPath[1] as! Keys, Keys.Key2)
+
+            let container4 = container3.nestedUnkeyedContainer()
+            XCTAssertEqual(container4.codingPath.count, 3)
+            XCTAssertEqual(container4.codingPath[0] as! Keys, Keys.Key1)
+            XCTAssertEqual(container4.codingPath[1] as! Keys, Keys.Key2)
+            XCTAssertEqual(
+                container4.codingPath[2] as! MsgpackCodingKey,
+                MsgpackCodingKey(intValue: 0))
+        }
+
+        enum Keys: CodingKey {
+            case Key1, Key2, superKey
+        }
+    }
+
+    func testCodingKey() throws {
+        let example = CodingKeyExample()
+        let encoder = MsgpackEncoder()
+        _ = try encoder.encode(example)
+    }
+
+    // MARK: Container properties
+    struct UnkeyedContainerCountExample: Encodable {
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.unkeyedContainer()
+            XCTAssertEqual(container.count, 0)
+            try container.encode(true)
+            XCTAssertEqual(container.count, 1)
+            _ = container.superEncoder().singleValueContainer()
+            XCTAssertEqual(container.count, 2)
+        }
+    }
+
+    func testUnkeyedContainerCount() throws {
+        let example = UnkeyedContainerCountExample()
+        let encoder = MsgpackEncoder()
+        _ = try encoder.encode(example)
+    }
+}
+
+// Used for debugging
+extension Data {
+    fileprivate func hexEncodedString() -> String {
+        return self.map { v in String(format: "%02hhx", v) }.joined()
+    }
+    fileprivate func hexEncodedArray() -> String {
+        return self.map { v in String(format: "0x%02hhx", v) }.joined(
+            separator: ",")
+    }
+}


### PR DESCRIPTION
This PR adds  implementation for the [Messagepack protocol](https://github.com/msgpack/msgpack/blob/master/spec.md) which follows the Swift [Codable](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0166-swift-archival-serialization.md) 

The Serialzation/Deseriazation flow is `Swift Type -> MsgpackType -> Data -> MsgpackType -> Swift Type`.