### PR TITLE
fix client invocation empty result issue

### DIFF
--- a/Sources/SignalRClient/Protocols/MessagePackHubProtocol.swift
+++ b/Sources/SignalRClient/Protocols/MessagePackHubProtocol.swift
@@ -77,11 +77,12 @@ final class MessagePackHubProtocol: HubProtocol {
                     1,
                     message.error,
                 ]
-            } else if message.result.value == nil {
-                arr = [
-                    message.type, message.headers ?? [:], message.invocationId,
-                    2,
-                ]
+                // Set ResultKind = 2 will trigger a server side issue
+//            } else if message.result.value == nil {
+//                arr = [
+//                    message.type, message.headers ?? [:], message.invocationId,
+//                    2
+//                ]
             } else {
                 arr = [
                     message.type, message.headers ?? [:], message.invocationId,

--- a/Tests/SignalRClientIntegrationTests/IntegrationTests.swift
+++ b/Tests/SignalRClientIntegrationTests/IntegrationTests.swift
@@ -287,7 +287,7 @@ class IntegrationTests: XCTestCase {
     func testClientResultWithNull() async throws {
         #if os(Linux)
         let testCombinations: [(transport: HttpTransportType, hubProtocol: HubProtocolType)] = [
-            // (.longPolling, .messagePack), // TODO: This test fails, need more investigation
+             (.longPolling, .messagePack),
             (.longPolling, .json),
         ]
         #else
@@ -295,8 +295,8 @@ class IntegrationTests: XCTestCase {
             (.webSockets, .json),
             (.serverSentEvents, .json),
             (.longPolling, .json),
-            // (.webSockets, .messagePack), // TODO: This test fails, need more investigation
-            // (.longPolling, .messagePack), // TODO: This test fails, need more investigation
+             (.webSockets, .messagePack),
+             (.longPolling, .messagePack),
         ]
         #endif
 

--- a/Tests/SignalRClientTests/MessagePackHubProtocolTests.swift
+++ b/Tests/SignalRClientTests/MessagePackHubProtocolTests.swift
@@ -119,7 +119,11 @@ class MessagePackHubProtocolTests: XCTestCase {
 
         switch try msgpack.writeMessage(message: message) {
         case .data(let d):
-            XCTAssertEqual(d, try BinaryMessageFormat.write(data))
+//            XCTAssertEqual(d, try BinaryMessageFormat.write(data))
+            // Encoded to resultKind = 3
+            XCTAssertEqual(d, try BinaryMessageFormat.write(Data([
+                0x95, 0x03, 0x80, 0xa3, 0x78, 0x79, 0x7a, 0x03,0xc0
+            ])))
         default:
             XCTFail("Wrong encoded typed")
         }


### PR DESCRIPTION
### Fix issue: Server throws empty exception when receiving `CompletionMessage` with VoidResultKind in message pack protocol

### Root Cause
[Server code](https://github.com/dotnet/aspnetcore/blob/5b04fe32b2db654e9e3abb00c70e2e12d09d5a38/src/SignalR/common/Shared/ClientResultsManager.cs#L30) throws exception when the `HasResult` is `false`.

### Why it works well for Json
For [MessagepackHubProtocol](https://github.com/dotnet/aspnetcore/blob/fb5c9c59b678e2319bb83104eba37ce0d95b1137/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs#L204), the `HasResult` is decoded from the `CompletionMessage`. For [JsonHubProtocol](https://github.com/dotnet/aspnetcore/blob/fb5c9c59b678e2319bb83104eba37ce0d95b1137/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs#L224), the `HasResult` is not decoded but inferred.

### Work Around
Encode empty result as `null` instead of `VoidResultKind` in the client side
Looks the same issue exists for other SignalR clients too. 