### PR TITLE
Make HubConnectionState Sendable

### DIFF
--- a/Sources/SignalRClient/HubConnection.swift
+++ b/Sources/SignalRClient/HubConnection.swift
@@ -805,7 +805,7 @@ public actor HubConnection {
     }
 }
 
-public enum HubConnectionState {
+public enum HubConnectionState: Sendable {
     // The connection is stopped. Start can only be called if the connection is in this state.
     case Stopped
     case Connecting


### PR DESCRIPTION
In the `HubConnection` actor the current state is exposed by the `state()` function. The state itself currently isn't sendable, which causes it to be not usable with strict concurrency, as it would always has to be sent outside of the actor.

This PR adds sendability to `HubConnectionState`.