### PR TITLE
fix ci/cd failure by updating mac os version

### DIFF
--- a/.github/workflows/swift-e2e.yml
+++ b/.github/workflows/swift-e2e.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-14]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-14]
     steps:
     - uses: actions/checkout@v4
     - uses: swift-actions/setup-swift@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-14]
     steps:
     - uses: actions/checkout@v4
     - uses: swift-actions/setup-swift@v2


### PR DESCRIPTION
root cause is https://github.com/actions/runner-images/issues/12520 and I use its recommended mitigation ways.