### PR TITLE
Connection status stream support

### DIFF
--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // MARK: - Enums and Protocols
 
-private enum ConnectionState: String {
+public enum ConnectionState: String, Sendable {
     case connecting = "Connecting"
     case connected = "Connected"
     case disconnected = "Disconnected"
@@ -72,7 +72,12 @@ actor HttpConnection: ConnectionProtocol {
     // MARK: - Properties
     private let negotiationRedirectionLimit = 100
 
-    private var connectionState: ConnectionState = .disconnected
+    nonisolated public let connectionStateUpdates: AsyncStream<ConnectionState>
+    private let stateUpdateContinuation: AsyncStream<ConnectionState>.Continuation
+    private var connectionState: ConnectionState = .disconnected {
+        didSet { stateUpdateContinuation.yield(connectionState) }
+    }
+
     private var connectionStartedSuccessfully: Bool = false
     private let httpClient: AccessTokenHttpClient
     private let logger: Logger
@@ -92,7 +97,7 @@ actor HttpConnection: ConnectionProtocol {
             return inherentKeepAlivePrivate
         }
     }
-
+    
     private var onReceive: Transport.OnReceiveHandler?
     private var onClose: Transport.OnCloseHander?
     private let negotiateVersion = 1
@@ -112,6 +117,12 @@ actor HttpConnection: ConnectionProtocol {
 
         self.accessTokenFactory = options.accessTokenFactory
         self.httpClient = AccessTokenHttpClient(innerClient: options.httpClient ?? DefaultHttpClient(logger: logger), accessTokenFactory: options.accessTokenFactory)
+
+        (connectionStateUpdates, stateUpdateContinuation) = AsyncStream.makeStream(of: ConnectionState.self)
+    }
+
+    deinit {
+        stateUpdateContinuation.finish()
     }
 
     // MARK: - Public Methods

--- a/Sources/SignalRClient/HubConnection.swift
+++ b/Sources/SignalRClient/HubConnection.swift
@@ -25,7 +25,11 @@ public actor HubConnection {
     private var receivedHandshakeResponse: Bool = false
     private var invocationId: Int = 0
     private var messageBuffer: MessageBuffer? = nil
-    private var connectionStatus: HubConnectionState = .Stopped
+    nonisolated public let connectionStatusUpdates: AsyncStream<HubConnectionState>
+    private let statusUpdateContinuation: AsyncStream<HubConnectionState>.Continuation
+    private var connectionStatus: HubConnectionState = .Stopped {
+        didSet { statusUpdateContinuation.yield(connectionStatus) }
+    }
     private var stopping: Bool = false
     private var stopDuringStartError: Error?
     private nonisolated(unsafe) var handshakeResolver: ((HandshakeResponseMessage) -> Void)?
@@ -62,6 +66,12 @@ public actor HubConnection {
         self.serverTimeoutScheduler = TimeScheduler(initialInterval: self.serverTimeout)
         self.reconnectedHandlers = []
         self.reconnectingHandlers = []
+
+        (connectionStatusUpdates, statusUpdateContinuation) = AsyncStream.makeStream(of: HubConnectionState.self)
+    }
+
+    deinit {
+        statusUpdateContinuation.finish()
     }
 
     public func start() async throws {


### PR DESCRIPTION
This PR adds support to observe the HTTP and Hub connection status as an AsyncStream.
I've added it to both for consistency.
This did require the HTTP `ConnectionState` enum to be made public and sendable.